### PR TITLE
feat(ui): torn-paper ribbon header nav + button pattern cleanup

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { useToast } from "@/components/ui/use-toast"
-import { Loader2, Calendar as CalendarIcon, Clock, ChevronLeft, ChevronRight, Image as ImageIcon, BookOpen, Download, Plus, Activity, Check, ExternalLink } from "lucide-react"
+import { Loader2, Calendar as CalendarIcon, Clock, ChevronLeft, ChevronRight, Image as ImageIcon, BookOpen, Download, Plus, Activity, Check, ExternalLink, Eye } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
@@ -318,8 +318,8 @@ export default function CalendarPage() {
                                                     
                                                     {/* Hidden on mobile to prevent overlay flash issues, visible on desktop hover */}
                                                     <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex items-center justify-center z-10 pointer-events-none">
-                                                        <Button size="sm" className="font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg pointer-events-auto" tabIndex={-1}>
-                                                            <BookOpen className="w-4 h-4 mr-2" /> View Series
+                                                        <Button size="sm" className="font-bold shadow-md pointer-events-auto" tabIndex={-1}>
+                                                            <Eye className="w-3 h-3 mr-2" /> View Series
                                                         </Button>
                                                     </div>
                                                 </div>
@@ -411,13 +411,13 @@ export default function CalendarPage() {
                                                 {/* Desktop Only Hover Overlay */}
                                                 <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex flex-col items-center justify-center z-10 p-2 gap-2">
                                                     {isMonitored ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100">
-                                                            <Check className="w-4 h-4 mr-2"/> {inLibrary ? "Monitored" : "Subscribed"}
+                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
+                                                            <Check className="w-3 h-3 mr-2"/> {inLibrary ? "Monitored" : "Subscribed"}
                                                         </Button>
                                                     ) : (
-                                                        <Button 
-                                                            size="sm" 
-                                                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg"
+                                                        <Button
+                                                            size="sm"
+                                                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
                                                             disabled={requestingTarget === `vol-${volIdKey}`}
                                                             onClick={(e) => {
                                                                 e.preventDefault();
@@ -425,19 +425,19 @@ export default function CalendarPage() {
                                                                 setMonitorPrompt({ id: volIdKey, name: issue.seriesName, image: issue.coverUrl || "", year: issue.year || "", publisher: issue.publisher, issueNumber: issue.issueNumber, metadataSource: (issue as any).metadataSource || 'METRON' })
                                                             }}
                                                         >
-                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Plus className="w-4 h-4 mr-2" />} Request Series
+                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Plus className="w-3 h-3 mr-2" />} Request
                                                         </Button>
                                                     )}
 
                                                     {isIssueRequested ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100">
-                                                            <Check className="w-4 h-4 mr-2"/> Requested
+                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
+                                                            <Check className="w-3 h-3 mr-2"/> Requested
                                                         </Button>
                                                     ) : (
-                                                        <Button 
-                                                            size="sm" 
+                                                        <Button
+                                                            size="sm"
                                                             variant="outline"
-                                                            className="w-full font-bold text-white border-white/30 hover:bg-white/20"
+                                                            className="w-full font-bold text-white border-white/30 hover:bg-white/20 shadow-md"
                                                             disabled={requestingTarget === `iss-${issueTargetName}` || isMonitored}
                                                             onClick={(e) => {
                                                                 e.preventDefault();
@@ -445,7 +445,7 @@ export default function CalendarPage() {
                                                                 handleRequest(volIdKey, compositeName, issue.coverUrl || "", issue.year || "", 'issue', issue.publisher, false, issue.issueNumber, (issue as any).metadataSource || 'METRON', false, issue.releaseDate)
                                                             }}
                                                         >
-                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Download className="w-4 h-4 mr-2" />} Request Issue
+                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Download className="w-3 h-3 mr-2" />} Request Issue
                                                         </Button>
                                                     )}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
 
 /* --- PLUGINS --- */
 @plugin "@tailwindcss/typography"; /* Loads the prose classes for sanitized HTML styling */
@@ -278,4 +279,86 @@
   ::-webkit-scrollbar-corner {
     background: transparent;
   }
+}
+
+/* ===== TORN PAPER RIBBON NAV ===== */
+@layer components {
+  .ribbon-nav {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    height: 100%;
+  }
+
+  .ribbon-link {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.04em;
+    color: hsl(var(--muted-foreground));
+    padding: 8px 12px;
+    border-radius: var(--radius) var(--radius) 0 0;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    position: relative;
+    --ribbon-color: hsl(var(--primary));
+  }
+
+  @media (min-width: 1280px) {
+    .ribbon-link {
+      font-size: 15px;
+      letter-spacing: 0.05em;
+      padding: 10px 16px;
+    }
+  }
+
+  .ribbon-link:hover {
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted));
+  }
+
+  .ribbon-link.active {
+    color: hsl(var(--background));
+    background: var(--ribbon-color);
+    margin-top: -4px;
+    padding-top: 14px;
+    box-shadow: 0 -4px 24px color-mix(in oklch, var(--ribbon-color) 45%, transparent);
+    clip-path: polygon(
+      0 0, 100% 0,
+      100% calc(100% - 2px), 95% 100%, 90% calc(100% - 3px),
+      85% 100%, 80% calc(100% - 2px), 75% 100%,
+      70% calc(100% - 3px), 65% 100%, 60% calc(100% - 2px),
+      55% 100%, 50% calc(100% - 3px), 45% 100%,
+      40% calc(100% - 2px), 35% 100%, 30% calc(100% - 3px),
+      25% 100%, 20% calc(100% - 2px), 15% 100%,
+      10% calc(100% - 3px), 5% 100%, 0 calc(100% - 2px)
+    );
+  }
+
+  .ribbon-link.active::after {
+    content: '';
+    position: absolute;
+    bottom: -12px;
+    left: 0;
+    right: 0;
+    height: 12px;
+    background: var(--ribbon-color);
+    clip-path: polygon(
+      0 0, 100% 0,
+      100% 30%, 90% 60%, 80% 30%, 70% 70%,
+      60% 40%, 50% 100%, 40% 50%, 30% 70%,
+      20% 30%, 10% 60%, 0 30%
+    );
+    filter: drop-shadow(0 4px 8px color-mix(in oklch, var(--ribbon-color) 50%, transparent));
+  }
+
+  /* Color variants */
+  .ribbon-red { --ribbon-color: oklch(0.62 0.22 25); }
+  .ribbon-blue { --ribbon-color: oklch(0.55 0.20 240); }
+  .ribbon-green { --ribbon-color: oklch(0.6 0.2 145); }
+  .ribbon-purple { --ribbon-color: oklch(0.55 0.25 290); }
+  .ribbon-yellow { --ribbon-color: oklch(0.80 0.18 85); }
 }

--- a/src/app/library/history/page.tsx
+++ b/src/app/library/history/page.tsx
@@ -55,15 +55,15 @@ export default function HistoryPage() {
 
                         {/* Hover action overlay */}
                         <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center p-4 z-20">
-                            <Button 
-                                size="sm" 
-                                className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg" 
-                                onClick={(e) => { 
-                                    e.stopPropagation(); 
-                                    router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`); 
+                            <Button
+                                size="sm"
+                                className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`);
                                 }}
                             >
-                                <BookOpen className="w-4 h-4 mr-2" /> {item.isCompleted ? "Re-read" : "Resume"}
+                                <BookOpen className="w-3 h-3 mr-2" /> {item.isCompleted ? "Re-read" : "Resume"}
                             </Button>
                         </div>
                         

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1020,53 +1020,50 @@ function LibraryContent() {
                       </div>
 
                         <div className={`absolute inset-0 bg-black/80 transition-opacity flex-col items-center justify-center gap-1.5 p-3 z-20 pointer-events-none group-hover:pointer-events-auto ${isSelectionMode ? 'hidden' : 'hidden md:flex opacity-0 group-hover:opacity-100'}`}>
-                        <Button 
-                            variant="default" 
-                            size="sm" 
-                            className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 min-w-0 px-2" 
+                        <Button
+                            variant="default"
+                            size="sm"
+                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                             onClick={(e) => handleNavigate(e as any, item.path, navId)}
                             aria-label={`Open reader for ${item.name}`}
                         >
-                            {navigatingTo === navId ? <Loader2 className="w-3 h-3 mr-1.5 animate-spin shrink-0" /> : <BookOpen className="w-3 h-3 mr-1.5 shrink-0" />} 
-                            <span className="truncate">{navigatingTo === navId ? "Loading..." : "Read Series"}</span>
+                            {navigatingTo === navId ? <Loader2 className="w-3 h-3 animate-spin shrink-0" /> : <BookOpen className="w-3 h-3 shrink-0" />}
+                            <span>{navigatingTo === navId ? "Loading..." : "Read"}</span>
                         </Button>
-                        <div className="flex gap-1.5 w-full">
-                          <Button 
-                            variant="secondary" 
-                            size="sm" 
-                            className="h-10 sm:h-8 flex-1 shadow-lg font-bold px-1.5 min-w-0 flex items-center justify-center" 
+                        <div className="flex gap-1.5 w-full justify-center">
+                          <Button
+                            variant="secondary"
+                            size="icon-sm"
+                            className="shadow-md"
                             onClick={(e) => { e.preventDefault(); e.stopPropagation(); setTargetSeries(item); }}
                             title="Add to List"
                             aria-label={`Add ${item.name} to a reading list`}
                         >
-                            <ListPlus className="w-4 h-4 shrink-0" /> 
+                            <ListPlus className="w-4 h-4" />
                         </Button>
                         {isAdmin && (
-                            <Button 
-                                variant="secondary" 
-                                size="sm" 
-                                className="h-10 sm:h-8 flex-1 shadow-lg font-bold px-1.5 min-w-0 flex items-center justify-center" 
+                            <Button
+                                variant="secondary"
+                                size="icon-sm"
+                                className="shadow-md"
                                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); setEditing(item); }}
                                 title="Edit Metadata"
                                 aria-label={`Edit metadata for ${item.name}`}
                             >
-                                <Settings2 className="w-4 h-4 shrink-0" /> 
+                                <Settings2 className="w-4 h-4" />
                             </Button>
                             )}
-                        </div>
                         {isAdmin && (
-                            // --- NEW: Using the new explicit Metadata variables ---
-                            <Button aria-label={`Refresh cover art for ${item.name}`} variant="default" size="sm" className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold border-0 min-w-0 px-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); initiateRefreshMetadata(item.metadataId || item.cvId?.toString(), item.metadataSource || 'COMICVINE', item.path); }}>
-                                <RefreshCw className="w-3 h-3 mr-1.5 shrink-0" /> 
-                                <span className="truncate">Fetch Cover</span>
+                            <Button aria-label={`Refresh cover art for ${item.name}`} variant="secondary" size="icon-sm" className="shadow-md" onClick={(e) => { e.preventDefault(); e.stopPropagation(); initiateRefreshMetadata(item.metadataId || item.cvId?.toString(), item.metadataSource || 'COMICVINE', item.path); }} title="Refresh Cover">
+                                <RefreshCw className="w-4 h-4" />
                             </Button>
                         )}
                         {activeCollection !== "ALL" && (
-                            <Button aria-label={`Remove ${item.name} from current list`} variant="destructive" size="sm" className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold min-w-0 px-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleRemoveFromCollection(item.id); }}>
-                                <Minus className="w-3 h-3 mr-1.5 shrink-0" /> 
-                                <span className="truncate">Remove</span>
+                            <Button aria-label={`Remove ${item.name} from current list`} variant="destructive" size="icon-sm" className="shadow-md" onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleRemoveFromCollection(item.id); }} title="Remove from List">
+                                <Minus className="w-4 h-4" />
                             </Button>
                         )}
+                        </div>
                       </div>
                   </Card>
                   <div 

--- a/src/app/library/series/page.tsx
+++ b/src/app/library/series/page.tsx
@@ -1688,20 +1688,20 @@ function SeriesContent() {
                                     <div className="flex flex-col justify-between flex-1 py-1 min-w-0">
                                       <div><h5 className={`font-bold text-base line-clamp-2 leading-tight ${isRead ? 'text-muted-foreground' : 'text-foreground'}`}>{issue.name}</h5>{issue.parsedNum !== null && <span className="text-[10px] mt-1 font-black text-muted-foreground uppercase tracking-widest">Issue #{issue.parsedNum}</span>}</div>
                                       <div className="flex flex-wrap items-center gap-1.5 mt-3">
-                                        <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="flex-1 h-9 text-[11px] font-black uppercase tracking-wider min-w-[70px]" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
+                                        <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="flex-1 font-bold shadow-md min-w-[70px]" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
                                             <Link href={`/reader?path=${encodeURIComponent(issue.fullPath)}&series=${encodeURIComponent(folderPath || '')}`}>
                                                 {getReadButtonLabel(issue)}
                                             </Link>
                                         </Button>
-                                        
+
                                         {!isSelectionMode && (
-                                            <Button size="sm" variant="ghost" className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
+                                            <Button size="icon-sm" variant="ghost" className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
                                                 {isRead ? <EyeOff className="w-4 h-4" /> : <CheckCircle2 className="w-4 h-4" />}
                                             </Button>
                                         )}
 
                                         {canDownload && !isSelectionMode && (
-                                            <Button size="sm" variant="secondary" className="h-9 w-9 p-0 flex items-center justify-center bg-muted hover:bg-muted/80 text-foreground border-border shrink-0" asChild onClick={(e) => e.stopPropagation()}>
+                                            <Button size="icon-sm" variant="secondary" className="shrink-0" asChild onClick={(e) => e.stopPropagation()}>
                                                 <a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download>
                                                     <Download className="w-4 h-4" />
                                                 </a>
@@ -1709,7 +1709,7 @@ function SeriesContent() {
                                         )}
 
                                         {isAdmin && !isSelectionMode && (
-                                            <Button size="sm" variant="ghost" className="h-9 w-9 p-0 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0 border border-transparent hover:border-red-200 dark:hover:border-red-900/50" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
+                                            <Button size="icon-sm" variant="ghost" className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}
@@ -1772,18 +1772,18 @@ function SeriesContent() {
                                                   <td className="px-4 py-3 text-right">
                                                       <div className="flex items-center justify-end gap-2">
                                                           {!isSelectionMode && (
-                                                              <Button size="sm" variant="ghost" className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
+                                                              <Button size="icon-sm" variant="ghost" className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
                                                                   {isRead ? <EyeOff className="w-4 h-4" /> : <CheckCircle2 className="w-4 h-4" />}
                                                               </Button>
                                                           )}
-                                                          <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="h-8 text-[11px] font-black uppercase tracking-wider" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
+                                                          <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="font-bold shadow-md" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
                                                               <Link href={`/reader?path=${encodeURIComponent(issue.fullPath)}&series=${encodeURIComponent(folderPath || '')}`}>
                                                                   {getReadButtonLabel(issue)}
                                                               </Link>
                                                           </Button>
-                                                          {canDownload && !isSelectionMode && <Button size="sm" variant="secondary" className="h-8 px-3 bg-muted hover:bg-muted/80 text-foreground border-border hidden sm:flex" asChild onClick={(e) => e.stopPropagation()}><a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download><Download className="w-4 h-4" /></a></Button>}
+                                                          {canDownload && !isSelectionMode && <Button size="icon-sm" variant="secondary" className="shrink-0 hidden sm:flex" asChild onClick={(e) => e.stopPropagation()}><a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download><Download className="w-4 h-4" /></a></Button>}
                                                           {isAdmin && !isSelectionMode && (
-                                                              <Button size="sm" variant="ghost" className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 hidden sm:flex" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
+                                                              <Button size="icon-sm" variant="ghost" className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0 hidden sm:flex" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
                                                                   <Trash2 className="w-4 h-4" />
                                                               </Button>
                                                           )}
@@ -2010,7 +2010,7 @@ function SeriesContent() {
                               <div className="aspect-[2/3] bg-muted rounded-lg overflow-hidden border border-border relative shadow-sm">
                                   {item.image && <img src={getImageUrl(item.image) || ""} className="object-cover w-full h-full" alt="" />}
                                   <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                                      <Button size="sm" className="font-bold shadow-lg" disabled={isMatching}>
+                                      <Button size="sm" className="font-bold shadow-md" disabled={isMatching}>
                                           {isMatching ? <Loader2 className="animate-spin w-4 h-4" /> : "Select"}
                                       </Button>
                                   </div>

--- a/src/components/ContinueReading.tsx
+++ b/src/components/ContinueReading.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { BookOpen, Image as ImageIcon, X, ArrowRight } from "lucide-react"; 
+import { BookOpen, Image as ImageIcon, RotateCcw, ArrowRight } from "lucide-react"; 
 import { Button } from "@/components/ui/button";
 import Link from "next/link"; 
 import { Logger } from "@/lib/logger";
@@ -90,7 +90,7 @@ export function ContinueReading() {
         <h2 className="text-2xl font-bold tracking-tight text-foreground">Jump Back In</h2>
         <Button asChild variant="outline" size="sm" className="border-primary/50 text-primary hover:bg-primary/10 group font-bold hidden sm:flex">
             <Link href="/library/history">
-                View History <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>History</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>
@@ -129,22 +129,22 @@ export function ContinueReading() {
                   
                   <Button 
                       size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`);
                       }}
                   >
-                      <BookOpen className="w-3 h-3 mr-2" /> Resume
+                      <BookOpen className="w-3 h-3 shrink-0" /> <span>Resume</span>
                   </Button>
 
-                  <Button 
-                      variant="secondary" 
-                      size="sm" 
-                      className="w-full font-bold shadow-md" 
+                  <Button
+                      variant="secondary"
+                      size="sm"
+                      className="w-full min-w-0 font-bold shadow-md"
                       onClick={(e) => handleMarkUnread(e, item.id)}
                   >
-                      <X className="w-3 h-3 mr-1" /> Mark Unread
+                      <RotateCcw className="w-3 h-3 shrink-0" /> <span>Unread</span>
                   </Button>
               </div>
             </div>
@@ -154,7 +154,7 @@ export function ContinueReading() {
       <div className="sm:hidden pt-2">
         <Button asChild variant="outline" className="w-full border-primary/50 text-primary hover:bg-primary/10 group font-bold">
             <Link href="/library/history">
-                View History <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>History</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>

--- a/src/components/comic-grid.tsx
+++ b/src/components/comic-grid.tsx
@@ -322,7 +322,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                 </div>
                 
                 <div className="absolute inset-0 hidden sm:flex opacity-0 group-hover:opacity-100 transition-opacity items-center justify-center z-40 pointer-events-none">
-                  <Button size="sm" className="font-bold shadow-lg bg-primary hover:bg-primary/90 text-primary-foreground pointer-events-auto transition-transform group-hover:scale-110" tabIndex={-1}>Details</Button>
+                  <Button size="sm" className="font-bold shadow-md pointer-events-auto transition-transform group-hover:scale-110" tabIndex={-1}>Details</Button>
                 </div>
             </div>
           )})}

--- a/src/components/recently-added.tsx
+++ b/src/components/recently-added.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Library, Image as ImageIcon, ArrowRight } from "lucide-react"; 
+import { Eye, Image as ImageIcon, ArrowRight } from "lucide-react"; 
 import { Button } from "@/components/ui/button";
 import Link from "next/link"; 
 
@@ -29,7 +29,7 @@ export function RecentlyAdded() {
         <h2 className="text-2xl font-bold tracking-tight text-foreground">Recently Added</h2>
         <Button asChild variant="outline" size="sm" className="border-primary/50 text-primary hover:bg-primary/10 group font-bold hidden sm:flex">
             <Link href="/library">
-                View Library <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>Library</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>
@@ -62,15 +62,15 @@ export function RecentlyAdded() {
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   
-                  <Button 
-                      size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                  <Button
+                      size="sm"
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/library/series?path=${encodeURIComponent(item.path)}`);
                       }}
                   >
-                      <Library className="w-3 h-3 mr-2" /> View Series
+                      <Eye className="w-3 h-3 shrink-0" /> <span>View</span>
                   </Button>
               </div>
             </div>
@@ -80,7 +80,7 @@ export function RecentlyAdded() {
       <div className="sm:hidden pt-2">
         <Button asChild variant="outline" className="w-full border-primary/50 text-primary hover:bg-primary/10 group font-bold">
             <Link href="/library">
-                View Library <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>Library</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>

--- a/src/components/recommendations-shelf.tsx
+++ b/src/components/recommendations-shelf.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Sparkles, Image as ImageIcon, Library } from "lucide-react"; 
+import { Sparkles, Image as ImageIcon, Library, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function RecommendationsShelf() {
@@ -64,15 +64,15 @@ export function RecommendationsShelf() {
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   
-                  <Button 
-                      size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                  <Button
+                      size="sm"
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/library/series?path=${encodeURIComponent(item.path)}`);
                       }}
                   >
-                      <Library className="w-3 h-3 mr-2" /> View Series
+                      <Eye className="w-3 h-3 shrink-0" /> <span>View</span>
                   </Button>
               </div>
             </div>

--- a/src/components/request-search.tsx
+++ b/src/components/request-search.tsx
@@ -338,7 +338,7 @@ export function RequestSearch() {
                         {volStatus === 'PENDING_APPROVAL' && (<div className="absolute top-2 right-2 bg-yellow-500 text-white rounded-full p-1 z-10 shadow-md" title="Pending Admin Approval"><Clock className="w-4 h-4" /></div>)}
                         
                         <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center z-20">
-                          <Button size="sm" className="font-bold shadow-lg bg-primary hover:bg-primary/90 text-primary-foreground">Details</Button>
+                          <Button size="sm" className="font-bold shadow-md">Details</Button>
                         </div>
                       </div>
                       

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { useSession, signOut } from "next-auth/react"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
@@ -73,8 +74,8 @@ function NotificationBell() {
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative h-10 w-10 sm:h-9 sm:w-9 group hover:bg-primary/10 transition-colors">
-          <Bell className="h-6 w-6 sm:h-5 sm:w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+        <Button variant="ghost" size="icon" className="relative h-10 w-10 group hover:bg-primary/10 transition-colors">
+          <Bell className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
           {notifications.length > 0 && (
             <span className="absolute top-1.5 right-1.5 flex h-2.5 w-2.5">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
@@ -190,6 +191,7 @@ export function SiteHeader() {
   const { data: session, status } = useSession()
   const { theme, setTheme, resolvedTheme } = useTheme()
   const { toast } = useToast()
+  const pathname = usePathname()
   
   const [mounted, setMounted] = useState(false)
   useEffect(() => { setMounted(true) }, [])
@@ -256,14 +258,14 @@ export function SiteHeader() {
       className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shadow-sm transition-colors duration-300"
     >
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6">
-        
-        <div className="flex gap-2 sm:gap-6 items-center">
-          
-          {/* MOBILE HAMBURGER MENU */}
+
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0">
+
+          {/* MOBILE HAMBURGER MENU — shows below lg */}
           {!mounted ? (
-             <div className="md:hidden w-10 h-10 shrink-0" />
+             <div className="lg:hidden w-10 h-10 shrink-0" />
           ) : session ? (
-            <div className="md:hidden flex items-center">
+            <div className="lg:hidden flex items-center shrink-0">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" size="icon" className="h-10 w-10 shrink-0">
@@ -271,19 +273,19 @@ export function SiteHeader() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-64 mt-2 p-2 bg-popover border-border shadow-xl rounded-xl z-50">
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname === "/" ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/">Home</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/library") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/library">Library</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/reading-lists") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/reading-lists">Reading Lists</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/requests") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/requests">My Requests</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/calendar") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/calendar">Release Calendar</Link>
                   </DropdownMenuItem>
                   {session?.user?.role === "ADMIN" && (
@@ -299,32 +301,26 @@ export function SiteHeader() {
             </div>
           ) : null}
 
-          <Link href="/" className="flex items-center transition-transform hover:scale-[1.02] text-foreground">
-            <OmnibusLogo className="w-36 sm:w-56 h-auto shrink-0" />
+          <Link href="/" className="flex items-center transition-transform hover:scale-[1.02] text-foreground shrink-0">
+            <OmnibusLogo className="w-28 sm:w-44 lg:w-56 h-auto" />
           </Link>
-          
-          {/* DESKTOP NAV */}
-          <nav className="hidden md:flex gap-6 ml-4 items-center">
-            <Link href="/" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Home</Link>
-            <Link href="/library" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Library</Link>
-            <Link href="/reading-lists" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Reading Lists</Link>
-            <Link href="/requests" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">My Requests</Link>
-            <Link href="/calendar" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Release Calendar</Link>
-            
-            {session?.user?.role === "ADMIN" && (
-                <Button variant="outline" size="sm" className="h-8 gap-1.5 border-primary/20 bg-primary/10 text-primary hover:bg-primary/20 hover:text-primary transition-colors" asChild>
-                  <Link href="/admin"><ShieldAlert className="w-3.5 h-3.5" /> Admin</Link>
-                </Button>
-            )}
+
+          {/* DESKTOP NAV — TORN PAPER RIBBON (lg+) */}
+          <nav className="ribbon-nav hidden lg:flex items-center">
+            <Link href="/" className={`ribbon-link ribbon-red ${pathname === "/" ? "active" : ""}`}>Home</Link>
+            <Link href="/library" className={`ribbon-link ribbon-blue ${pathname?.startsWith("/library") ? "active" : ""}`}>Library</Link>
+            <Link href="/reading-lists" className={`ribbon-link ribbon-green ${pathname?.startsWith("/reading-lists") ? "active" : ""}`}>Reading Lists</Link>
+            <Link href="/requests" className={`ribbon-link ribbon-purple ${pathname?.startsWith("/requests") ? "active" : ""}`}>My Requests</Link>
+            <Link href="/calendar" className={`ribbon-link ribbon-yellow ${pathname?.startsWith("/calendar") ? "active" : ""}`}>Calendar</Link>
           </nav>
         </div>
 
         {/* RIGHT SIDE ICONS */}
-        <div className="flex items-center gap-1 sm:gap-4">
+        <div className="flex items-center gap-2 sm:gap-3 shrink-0">
           {!mounted ? (
-            <div className="flex items-center gap-2 sm:gap-4">
+            <div className="flex items-center gap-2 sm:gap-3">
               <div className="hidden sm:block w-14 h-7 rounded-full bg-muted animate-pulse" />
-              <div className="w-10 h-10 rounded-full bg-muted animate-pulse ml-1" />
+              <div className="w-10 h-10 rounded-full bg-muted animate-pulse" />
             </div>
           ) : (
             <>
@@ -359,11 +355,11 @@ export function SiteHeader() {
               </button>
 
               {status === "loading" ? (
-                 <div className="w-10 h-10 bg-muted animate-pulse rounded-full ml-1" />
+                 <div className="w-10 h-10 bg-muted animate-pulse rounded-full" />
               ) : session ? (
                  <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                        <Button variant="outline" className="relative h-10 w-10 sm:h-10 sm:w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 ml-1 transition-colors">
+                        <Button variant="outline" className="relative h-10 w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 transition-colors">
                             {session.user?.image ? (
                               <img 
                                 src={session.user.image.startsWith('/') || session.user.image.startsWith('http') ? session.user.image : `/${session.user.image}`} 
@@ -371,38 +367,43 @@ export function SiteHeader() {
                                 className="w-full h-full object-cover" 
                               />
                               ) : (
-                                <UserIcon className="w-5 h-5 sm:w-5 sm:h-5 text-foreground" />
+                                <UserIcon className="w-5 h-5 text-foreground" />
                             )}
                         </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-64 sm:w-56 mt-2 sm:mt-0 p-2 sm:p-1 bg-popover border-border rounded-xl sm:rounded-md shadow-xl">
-                        <DropdownMenuLabel className="font-normal p-3 sm:p-2">
+                    <DropdownMenuContent align="end" className="w-56 p-1 bg-popover border-border rounded-md shadow-xl">
+                        <DropdownMenuLabel className="font-normal p-2">
                             <div className="flex flex-col space-y-1.5">
-                                <p className="text-base sm:text-sm font-bold leading-none">{session.user?.name}</p>
+                                <p className="text-sm font-bold leading-none">{session.user?.name}</p>
                                 <div className="flex items-center gap-2">
-                                    <p className="text-xs sm:text-[10px] uppercase font-bold tracking-wider text-muted-foreground">{session.user?.role}</p>
+                                    <p className="text-[10px] uppercase font-bold tracking-wider text-muted-foreground">{session.user?.role}</p>
                                     {session.user && <TierBadge user={session.user as any} />}
                                 </div>
                             </div>
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator className="bg-border" />
                         
-                        <div className="sm:hidden p-3 flex items-center justify-between">
+                        <div className="lg:hidden p-2 flex items-center justify-between">
                           <span className="text-sm font-medium">Dark Mode</span>
                           <Switch checked={isDark} onCheckedChange={(c) => setTheme(c ? "dark" : "light")} />
                         </div>
-                        <DropdownMenuSeparator className="bg-border sm:hidden" />
+                        <DropdownMenuSeparator className="bg-border lg:hidden" />
 
-                        <DropdownMenuItem asChild className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
-                            <Link href="/profile"><UserIcon className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Profile</Link>
+                        <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                            <Link href="/profile"><UserIcon className="w-4 h-4 mr-2" /> Profile</Link>
                         </DropdownMenuItem>
-                        <DropdownMenuItem className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors" onClick={() => setPassModalOpen(true)}>
-                            <Key className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Change Password
+                        <DropdownMenuItem className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors" onClick={() => setPassModalOpen(true)}>
+                            <Key className="w-4 h-4 mr-2" /> Change Password
                         </DropdownMenuItem>
+                        {session?.user?.role === "ADMIN" && (
+                          <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm text-primary hover:bg-primary/10 focus:bg-primary/20 focus:text-primary transition-colors">
+                            <Link href="/admin"><ShieldAlert className="w-4 h-4 mr-2" /> Admin Dashboard</Link>
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator className="bg-border my-1" />
-                        
-                        <DropdownMenuItem 
-                          className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors" 
+
+                        <DropdownMenuItem
+                          className="p-2 text-sm cursor-pointer rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors"
                           onClick={(e) => {
                             e.preventDefault();
                             signOut({ redirect: false }).then(() => {
@@ -410,7 +411,7 @@ export function SiteHeader() {
                             });
                           }}
                         >
-                            <LogOut className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Log Out
+                            <LogOut className="w-4 h-4 mr-2" /> Log Out
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                  </DropdownMenu>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex min-w-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- **Header redesign**: Comic/manga-inspired torn-paper ribbon navigation with color-coded ribbons per route (red/blue/green/purple/yellow) and active state highlighting via `usePathname`
- **Admin moved to avatar dropdown**: Removed Admin button from desktop nav, now lives in the user avatar menu (Profile > Change Password > Admin Dashboard > Log Out)
- **Responsive header**: Hamburger menu below `lg` (1024px), ribbon nav at `lg+`, logo scales across breakpoints (`w-28 sm:w-44 lg:w-56`), container width aligned with body pages
- **Button pattern cleanup**: Standardized card hover overlays to primary "Read" button full-width + secondary actions as icon-only buttons, applied consistently across library, series, calendar, and history pages
- **Bebas Neue font** added for ribbon labels

## Files changed (12)

**Header:**
- `src/components/site-header.tsx`
- `src/app/globals.css`

**Button pattern:**
- `src/components/ContinueReading.tsx`
- `src/components/comic-grid.tsx`
- `src/components/recently-added.tsx`
- `src/components/recommendations-shelf.tsx`
- `src/components/request-search.tsx`
- `src/components/ui/button.tsx`

**Responsive/button pattern applied to pages:**
- `src/app/calendar/page.tsx`
- `src/app/library/history/page.tsx`
- `src/app/library/page.tsx`
- `src/app/library/series/page.tsx`