### PR TITLE
feat(ui): comic panel-frame header nav + button pattern cleanup

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
 import { useToast } from "@/components/ui/use-toast"
-import { Loader2, Calendar as CalendarIcon, Clock, ChevronLeft, ChevronRight, Image as ImageIcon, BookOpen, Download, Plus, Activity, Check, ExternalLink } from "lucide-react"
+import { Loader2, Calendar as CalendarIcon, Clock, ChevronLeft, ChevronRight, Image as ImageIcon, BookOpen, Download, Plus, Activity, Check, ExternalLink, Eye } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
@@ -318,8 +318,8 @@ export default function CalendarPage() {
                                                     
                                                     {/* Hidden on mobile to prevent overlay flash issues, visible on desktop hover */}
                                                     <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex items-center justify-center z-10 pointer-events-none">
-                                                        <Button size="sm" className="font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg pointer-events-auto" tabIndex={-1}>
-                                                            <BookOpen className="w-4 h-4 mr-2" /> View Series
+                                                        <Button size="sm" className="font-bold shadow-md pointer-events-auto" tabIndex={-1}>
+                                                            <Eye className="w-3 h-3 mr-2" /> View Series
                                                         </Button>
                                                     </div>
                                                 </div>
@@ -411,13 +411,13 @@ export default function CalendarPage() {
                                                 {/* Desktop Only Hover Overlay */}
                                                 <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex flex-col items-center justify-center z-10 p-2 gap-2">
                                                     {isMonitored ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100">
-                                                            <Check className="w-4 h-4 mr-2"/> {inLibrary ? "Monitored" : "Subscribed"}
+                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
+                                                            <Check className="w-3 h-3 mr-2"/> {inLibrary ? "Monitored" : "Subscribed"}
                                                         </Button>
                                                     ) : (
-                                                        <Button 
-                                                            size="sm" 
-                                                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg"
+                                                        <Button
+                                                            size="sm"
+                                                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
                                                             disabled={requestingTarget === `vol-${volIdKey}`}
                                                             onClick={(e) => {
                                                                 e.preventDefault();
@@ -425,19 +425,19 @@ export default function CalendarPage() {
                                                                 setMonitorPrompt({ id: volIdKey, name: issue.seriesName, image: issue.coverUrl || "", year: issue.year || "", publisher: issue.publisher, issueNumber: issue.issueNumber, metadataSource: (issue as any).metadataSource || 'METRON' })
                                                             }}
                                                         >
-                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Plus className="w-4 h-4 mr-2" />} Request Series
+                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Plus className="w-3 h-3 mr-2" />} Request
                                                         </Button>
                                                     )}
 
                                                     {isIssueRequested ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100">
-                                                            <Check className="w-4 h-4 mr-2"/> Requested
+                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
+                                                            <Check className="w-3 h-3 mr-2"/> Requested
                                                         </Button>
                                                     ) : (
-                                                        <Button 
-                                                            size="sm" 
+                                                        <Button
+                                                            size="sm"
                                                             variant="outline"
-                                                            className="w-full font-bold text-white border-white/30 hover:bg-white/20"
+                                                            className="w-full font-bold text-white border-white/30 hover:bg-white/20 shadow-md"
                                                             disabled={requestingTarget === `iss-${issueTargetName}` || isMonitored}
                                                             onClick={(e) => {
                                                                 e.preventDefault();
@@ -445,7 +445,7 @@ export default function CalendarPage() {
                                                                 handleRequest(volIdKey, compositeName, issue.coverUrl || "", issue.year || "", 'issue', issue.publisher, false, issue.issueNumber, (issue as any).metadataSource || 'METRON', false, issue.releaseDate)
                                                             }}
                                                         >
-                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Download className="w-4 h-4 mr-2" />} Request Issue
+                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Download className="w-3 h-3 mr-2" />} Request Issue
                                                         </Button>
                                                     )}
 

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -257,7 +257,7 @@ export default function CalendarPage() {
                 </TabsList>
 
                 {/* TAB 1: MY TRACKED SERIES */}
-                <TabsContent value="my-pulls" className="space-y-6 animate-in fade-in duration-500">
+                <TabsContent value="my-pulls" className="space-y-6 animate-in fade-in duration-300">
                     <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-muted/50 p-4 rounded-xl border border-border">
                         <div className="flex items-center gap-2">
                             <Button variant="outline" size="sm" onClick={() => setLocalWeekOffset(w => w - 1)} disabled={loadingLocal} className="border-border">
@@ -295,7 +295,7 @@ export default function CalendarPage() {
                                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
                                     {monthIssues.map((issue) => (
                                         <Link key={issue.id} href={`/library/series?path=${encodeURIComponent(issue.seriesPath || '')}`} className="group block h-full">
-                                            <Card className="shadow-sm border-border bg-background overflow-hidden h-full flex flex-col hover:border-primary/50 transition-colors">
+                                            <Card className="shadow-sm border-border bg-background overflow-hidden h-full flex flex-col hover:border-primary/50 transition-colors duration-200">
                                                 <div className="relative aspect-[2/3] w-full bg-muted border-b border-border overflow-hidden">
                                                     {issue.coverUrl ? (
                                                         <img src={issue.coverUrl} className="w-full h-full object-cover transition-transform group-hover:scale-105 duration-300" alt="" />
@@ -317,7 +317,7 @@ export default function CalendarPage() {
                                                     )}
                                                     
                                                     {/* Hidden on mobile to prevent overlay flash issues, visible on desktop hover */}
-                                                    <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex items-center justify-center z-10 pointer-events-none">
+                                                    <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hidden sm:flex items-center justify-center z-10 pointer-events-none">
                                                         <Button size="sm" className="font-bold shadow-md pointer-events-auto" tabIndex={-1}>
                                                             <Eye className="w-3 h-3 mr-2" /> View Series
                                                         </Button>
@@ -342,7 +342,7 @@ export default function CalendarPage() {
                 </TabsContent>
 
                 {/* TAB 2: GLOBAL PULL LIST */}
-                <TabsContent value="global-pulls" className="space-y-6 animate-in fade-in duration-500">
+                <TabsContent value="global-pulls" className="space-y-6 animate-in fade-in duration-300">
                     <div className="flex flex-col sm:flex-row items-center justify-between gap-4 bg-muted/50 p-4 rounded-xl border border-border">
                         <div className="flex items-center gap-2">
                             <Button variant="outline" size="sm" onClick={() => setWeekOffset(w => w - 1)} disabled={loadingGlobal} className="border-border">
@@ -391,7 +391,7 @@ export default function CalendarPage() {
                                         const inLibrary = issue.inLibrary || isVolRequested;
 
                                         return (
-                                        <Card key={issue.id} className="group shadow-sm border-border bg-background overflow-hidden h-full flex flex-col hover:border-primary/50 transition-colors">
+                                        <Card key={issue.id} className="group shadow-sm border-border bg-background overflow-hidden h-full flex flex-col hover:border-primary/50 transition-colors duration-200">
                                             <div className="relative aspect-[2/3] w-full bg-muted border-b border-border overflow-hidden">
                                                 {issue.coverUrl ? <img src={issue.coverUrl} className="w-full h-full object-cover transition-transform group-hover:scale-105 duration-300" alt="" /> : <ImageIcon className="w-8 h-8 text-muted-foreground/30 m-auto h-full" />}
                                                 
@@ -409,56 +409,80 @@ export default function CalendarPage() {
                                                 </div>
 
                                                 {/* Desktop Only Hover Overlay */}
-                                                <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity hidden sm:flex flex-col items-center justify-center z-10 p-2 gap-2">
+                                                <div className="absolute inset-0 bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hidden sm:flex flex-col items-center justify-center z-10 p-2 gap-1.5">
                                                     {isMonitored ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
-                                                            <Check className="w-3 h-3 mr-2"/> {inLibrary ? "Monitored" : "Subscribed"}
-                                                        </Button>
+                                                        <>
+                                                            <Button size="sm" variant="secondary" disabled className="w-full text-[10px] font-bold whitespace-nowrap uppercase tracking-wider bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 border-2 border-white h-8 opacity-100 shadow-md">
+                                                                <Check className="w-3 h-3 mr-1"/> {inLibrary ? "Monitored" : "Subscribed"}
+                                                            </Button>
+                                                            <div className="flex flex-col gap-1.5 w-full">
+                                                                <Button
+                                                                    size="sm"
+                                                                    variant="outline"
+                                                                    disabled
+                                                                    className="text-[10px] font-bold whitespace-nowrap uppercase tracking-wider text-white border-2 border-white/50 h-8 opacity-50 cursor-not-allowed"
+                                                                >
+                                                                    <Download className="w-3 h-3 mr-1"/> Request Issue
+                                                                </Button>
+                                                                <Button
+                                                                    size="sm"
+                                                                    variant="ghost"
+                                                                    asChild
+                                                                    className="text-[10px] font-bold whitespace-nowrap uppercase tracking-wider text-white border-2 border-white/50 hover:bg-white/20 h-8"
+                                                                >
+                                                                    <a href={`https://metron.cloud/issue/${issue.id}/`} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
+                                                                        <ExternalLink className="w-3 h-3 mr-1"/> Details
+                                                                    </a>
+                                                                </Button>
+                                                            </div>
+                                                        </>
                                                     ) : (
-                                                        <Button
-                                                            size="sm"
-                                                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
-                                                            disabled={requestingTarget === `vol-${volIdKey}`}
-                                                            onClick={(e) => {
-                                                                e.preventDefault();
-                                                                e.stopPropagation();
-                                                                setMonitorPrompt({ id: volIdKey, name: issue.seriesName, image: issue.coverUrl || "", year: issue.year || "", publisher: issue.publisher, issueNumber: issue.issueNumber, metadataSource: (issue as any).metadataSource || 'METRON' })
-                                                            }}
-                                                        >
-                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Plus className="w-3 h-3 mr-2" />} Request
-                                                        </Button>
+                                                        <>
+                                                            <div className="flex flex-col gap-1.5 w-full">
+                                                                <Button
+                                                                    size="sm"
+                                                                    className="text-[10px] font-bold whitespace-nowrap uppercase tracking-wider bg-primary hover:bg-primary/90 text-primary-foreground border-2 border-white h-8"
+                                                                    disabled={requestingTarget === `vol-${volIdKey}`}
+                                                                    onClick={(e) => {
+                                                                        e.preventDefault();
+                                                                        e.stopPropagation();
+                                                                        setMonitorPrompt({ id: volIdKey, name: issue.seriesName, image: issue.coverUrl || "", year: issue.year || "", publisher: issue.publisher, issueNumber: issue.issueNumber, metadataSource: (issue as any).metadataSource || 'METRON' })
+                                                                    }}
+                                                                >
+                                                                    {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <Plus className="w-3 h-3 mr-1" />} Request Series
+                                                                </Button>
+                                                                {isIssueRequested ? (
+                                                                    <Button size="sm" variant="secondary" disabled className="text-[10px] font-bold whitespace-nowrap uppercase tracking-wider bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 border-2 border-white h-8 opacity-100 shadow-md">
+                                                                        <Check className="w-3 h-3 mr-1"/> Requested
+                                                                    </Button>
+                                                                ) : (
+                                                                    <Button
+                                                                        size="sm"
+                                                                        variant="outline"
+                                                                        className="text-[10px] font-bold whitespace-nowrap uppercase tracking-wider text-white border-2 border-white h-8 hover:bg-white/20"
+                                                                        disabled={requestingTarget === `iss-${issueTargetName}`}
+                                                                        onClick={(e) => {
+                                                                            e.preventDefault();
+                                                                            e.stopPropagation();
+                                                                            handleRequest(volIdKey, compositeName, issue.coverUrl || "", issue.year || "", 'issue', issue.publisher, false, issue.issueNumber, (issue as any).metadataSource || 'METRON', false, issue.releaseDate)
+                                                                        }}
+                                                                    >
+                                                                        {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-1" /> : <Download className="w-3 h-3 mr-1" />} Request Issue
+                                                                    </Button>
+                                                                )}
+                                                            </div>
+                                                            <Button
+                                                                size="sm"
+                                                                variant="ghost"
+                                                                asChild
+                                                                className="w-full text-[10px] font-bold whitespace-nowrap uppercase tracking-wider text-white border-2 border-white/50 hover:bg-white/20 h-7"
+                                                            >
+                                                                <a href={`https://metron.cloud/issue/${issue.id}/`} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
+                                                                    <ExternalLink className="w-3 h-3 mr-1" /> View Details
+                                                                </a>
+                                                            </Button>
+                                                        </>
                                                     )}
-
-                                                    {isIssueRequested ? (
-                                                        <Button size="sm" variant="secondary" disabled className="w-full font-bold bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400 opacity-100 shadow-md">
-                                                            <Check className="w-3 h-3 mr-2"/> Requested
-                                                        </Button>
-                                                    ) : (
-                                                        <Button
-                                                            size="sm"
-                                                            variant="outline"
-                                                            className="w-full font-bold text-white border-white/30 hover:bg-white/20 shadow-md"
-                                                            disabled={requestingTarget === `iss-${issueTargetName}` || isMonitored}
-                                                            onClick={(e) => {
-                                                                e.preventDefault();
-                                                                e.stopPropagation();
-                                                                handleRequest(volIdKey, compositeName, issue.coverUrl || "", issue.year || "", 'issue', issue.publisher, false, issue.issueNumber, (issue as any).metadataSource || 'METRON', false, issue.releaseDate)
-                                                            }}
-                                                        >
-                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-2" /> : <Download className="w-3 h-3 mr-2" />} Request Issue
-                                                        </Button>
-                                                    )}
-
-                                                    <Button 
-                                                        size="sm" 
-                                                        variant="ghost"
-                                                        asChild
-                                                        className="w-full font-bold text-white hover:bg-white/20 mt-1"
-                                                    >
-                                                        <a href={`https://metron.cloud/issue/${issue.id}/`} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
-                                                            <ExternalLink className="w-4 h-4 mr-2" /> View Details
-                                                        </a>
-                                                    </Button>
                                                 </div>
                                             </div>
                                             <CardContent className="p-3 flex-1 flex flex-col justify-between">
@@ -487,7 +511,7 @@ export default function CalendarPage() {
                                                                 setMonitorPrompt({ id: volIdKey, name: issue.seriesName, image: issue.coverUrl || "", year: issue.year || "", publisher: issue.publisher, issueNumber: issue.issueNumber, metadataSource: (issue as any).metadataSource || 'METRON' })
                                                             }}
                                                         >
-                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-1.5" /> : <Plus className="w-3 h-3 mr-1.5" />} Req Series
+                                                            {requestingTarget === `vol-${volIdKey}` ? <Loader2 className="w-3 h-3 animate-spin mr-1.5" /> : <Plus className="w-3 h-3 mr-1.5" />} Request Series
                                                         </Button>
                                                     )}
 
@@ -507,7 +531,7 @@ export default function CalendarPage() {
                                                                 handleRequest(volIdKey, compositeName, issue.coverUrl || "", issue.year || "", 'issue', issue.publisher, false, issue.issueNumber, (issue as any).metadataSource || 'METRON', false, issue.releaseDate)
                                                             }}
                                                         >
-                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-1.5" /> : <Download className="w-3 h-3 mr-1.5" />} Req Issue
+                                                            {requestingTarget === `iss-${issueTargetName}` ? <Loader2 className="w-3 h-3 animate-spin mr-1.5" /> : <Download className="w-3 h-3 mr-1.5" />} Request Issue
                                                         </Button>
                                                     )}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
 
 /* --- PLUGINS --- */
 @plugin "@tailwindcss/typography"; /* Loads the prose classes for sanitized HTML styling */
@@ -281,84 +280,11 @@
   }
 }
 
-/* ===== TORN PAPER RIBBON NAV ===== */
-@layer components {
-  .ribbon-nav {
-    display: flex;
-    align-items: flex-start;
-    gap: 4px;
-    height: 100%;
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
-
-  .ribbon-link {
-    font-family: 'Bebas Neue', sans-serif;
-    font-size: 14px;
-    letter-spacing: 0.04em;
-    color: hsl(var(--muted-foreground));
-    padding: 8px 12px;
-    border-radius: var(--radius) var(--radius) 0 0;
-    cursor: pointer;
-    transition: all 0.2s;
-    white-space: nowrap;
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    position: relative;
-    --ribbon-color: hsl(var(--primary));
-  }
-
-  @media (min-width: 1280px) {
-    .ribbon-link {
-      font-size: 15px;
-      letter-spacing: 0.05em;
-      padding: 10px 16px;
-    }
-  }
-
-  .ribbon-link:hover {
-    color: hsl(var(--foreground));
-    background: hsl(var(--muted));
-  }
-
-  .ribbon-link.active {
-    color: hsl(var(--background));
-    background: var(--ribbon-color);
-    margin-top: -4px;
-    padding-top: 14px;
-    box-shadow: 0 -4px 24px color-mix(in oklch, var(--ribbon-color) 45%, transparent);
-    clip-path: polygon(
-      0 0, 100% 0,
-      100% calc(100% - 2px), 95% 100%, 90% calc(100% - 3px),
-      85% 100%, 80% calc(100% - 2px), 75% 100%,
-      70% calc(100% - 3px), 65% 100%, 60% calc(100% - 2px),
-      55% 100%, 50% calc(100% - 3px), 45% 100%,
-      40% calc(100% - 2px), 35% 100%, 30% calc(100% - 3px),
-      25% 100%, 20% calc(100% - 2px), 15% 100%,
-      10% calc(100% - 3px), 5% 100%, 0 calc(100% - 2px)
-    );
-  }
-
-  .ribbon-link.active::after {
-    content: '';
-    position: absolute;
-    bottom: -12px;
-    left: 0;
-    right: 0;
-    height: 12px;
-    background: var(--ribbon-color);
-    clip-path: polygon(
-      0 0, 100% 0,
-      100% 30%, 90% 60%, 80% 30%, 70% 70%,
-      60% 40%, 50% 100%, 40% 50%, 30% 70%,
-      20% 30%, 10% 60%, 0 30%
-    );
-    filter: drop-shadow(0 4px 8px color-mix(in oklch, var(--ribbon-color) 50%, transparent));
-  }
-
-  /* Color variants */
-  .ribbon-red { --ribbon-color: oklch(0.62 0.22 25); }
-  .ribbon-blue { --ribbon-color: oklch(0.55 0.20 240); }
-  .ribbon-green { --ribbon-color: oklch(0.6 0.2 145); }
-  .ribbon-purple { --ribbon-color: oklch(0.55 0.25 290); }
-  .ribbon-yellow { --ribbon-color: oklch(0.80 0.18 85); }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap');
 
 /* --- PLUGINS --- */
 @plugin "@tailwindcss/typography"; /* Loads the prose classes for sanitized HTML styling */
@@ -278,4 +279,86 @@
   ::-webkit-scrollbar-corner {
     background: transparent;
   }
+}
+
+/* ===== TORN PAPER RIBBON NAV ===== */
+@layer components {
+  .ribbon-nav {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    height: 100%;
+  }
+
+  .ribbon-link {
+    font-family: 'Bebas Neue', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.04em;
+    color: hsl(var(--muted-foreground));
+    padding: 8px 12px;
+    border-radius: var(--radius) var(--radius) 0 0;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    position: relative;
+    --ribbon-color: hsl(var(--primary));
+  }
+
+  @media (min-width: 1280px) {
+    .ribbon-link {
+      font-size: 15px;
+      letter-spacing: 0.05em;
+      padding: 10px 16px;
+    }
+  }
+
+  .ribbon-link:hover {
+    color: hsl(var(--foreground));
+    background: hsl(var(--muted));
+  }
+
+  .ribbon-link.active {
+    color: hsl(var(--background));
+    background: var(--ribbon-color);
+    margin-top: -4px;
+    padding-top: 14px;
+    box-shadow: 0 -4px 24px color-mix(in oklch, var(--ribbon-color) 45%, transparent);
+    clip-path: polygon(
+      0 0, 100% 0,
+      100% calc(100% - 2px), 95% 100%, 90% calc(100% - 3px),
+      85% 100%, 80% calc(100% - 2px), 75% 100%,
+      70% calc(100% - 3px), 65% 100%, 60% calc(100% - 2px),
+      55% 100%, 50% calc(100% - 3px), 45% 100%,
+      40% calc(100% - 2px), 35% 100%, 30% calc(100% - 3px),
+      25% 100%, 20% calc(100% - 2px), 15% 100%,
+      10% calc(100% - 3px), 5% 100%, 0 calc(100% - 2px)
+    );
+  }
+
+  .ribbon-link.active::after {
+    content: '';
+    position: absolute;
+    bottom: -12px;
+    left: 0;
+    right: 0;
+    height: 12px;
+    background: var(--ribbon-color);
+    clip-path: polygon(
+      0 0, 100% 0,
+      100% 30%, 90% 60%, 80% 30%, 70% 70%,
+      60% 40%, 50% 100%, 40% 50%, 30% 70%,
+      20% 30%, 10% 60%, 0 30%
+    );
+    filter: drop-shadow(0 4px 8px color-mix(in oklch, var(--ribbon-color) 50%, transparent));
+  }
+
+  /* Color variants */
+  .ribbon-red { --ribbon-color: oklch(0.62 0.22 25); }
+  .ribbon-blue { --ribbon-color: oklch(0.55 0.20 240); }
+  .ribbon-green { --ribbon-color: oklch(0.6 0.2 145); }
+  .ribbon-purple { --ribbon-color: oklch(0.55 0.25 290); }
+  .ribbon-yellow { --ribbon-color: oklch(0.80 0.18 85); }
 }

--- a/src/app/library/history/page.tsx
+++ b/src/app/library/history/page.tsx
@@ -47,14 +47,14 @@ export default function HistoryPage() {
                     className="group space-y-2 cursor-pointer" 
                     onClick={() => router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`)}
                 >
-                    <div className="relative aspect-[2/3] rounded-xl overflow-hidden border border-border shadow-sm bg-muted transition-all group-hover:shadow-md group-hover:scale-[1.02] group-hover:ring-2 group-hover:ring-primary">
+                    <div className="relative aspect-[2/3] rounded-xl overflow-hidden border border-border shadow-sm bg-muted transition-[transform,box-shadow] duration-200 group-hover:shadow-md group-hover:scale-[1.02] group-hover:ring-2 group-hover:ring-primary">
                         <img src={item.seriesCoverUrl} className="w-full h-full object-cover" alt="" />
                         
                         {/* Gradient for progress bar visibility */}
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none group-hover:opacity-0 transition-opacity" />
+                        <div className="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none group-hover:opacity-0 transition-opacity duration-200" />
 
                         {/* Hover action overlay */}
-                        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center p-4 z-20">
+                        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center p-4 z-20">
                             <Button
                                 size="sm"
                                 className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
@@ -68,17 +68,17 @@ export default function HistoryPage() {
                         </div>
                         
                         {/* Floating Progress Bar */}
-                        <div className="absolute bottom-0 left-0 w-full p-2 z-20 group-hover:opacity-0 transition-opacity pointer-events-none">
+                        <div className="absolute bottom-0 left-0 w-full p-2 z-20 group-hover:opacity-0 transition-opacity duration-200 pointer-events-none">
                             <div className="flex justify-end mb-1">
                                 <p className="text-white/90 text-[10px] font-mono drop-shadow-md">{item.percentage}%</p>
                             </div>
-                            <div className="w-full bg-white/30 h-1.5 rounded-full overflow-hidden backdrop-blur-sm">
-                                <div className="bg-primary h-full transition-all duration-500 shadow-sm shadow-primary/50" style={{ width: `${item.percentage}%` }} />
+                            <div className="w-full bg-white/30 h-1.5 rounded-full overflow-hidden backdrop-blur-xs">
+                                <div className="bg-primary h-full transition-[width] duration-300 ease-out shadow-sm shadow-primary/50" style={{ width: `${item.percentage}%` }} />
                             </div>
                         </div>
                     </div>
                     <div className="px-0.5">
-                        <h3 className="text-sm font-bold truncate text-foreground group-hover:text-primary transition-colors">{item.seriesName}</h3>
+                        <h3 className="text-sm font-bold truncate text-foreground group-hover:text-primary transition-colors duration-200">{item.seriesName}</h3>
                         <p className="text-xs text-muted-foreground">Issue #{item.issueNumber}</p>
                     </div>
                 </div>

--- a/src/app/library/history/page.tsx
+++ b/src/app/library/history/page.tsx
@@ -55,15 +55,15 @@ export default function HistoryPage() {
 
                         {/* Hover action overlay */}
                         <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center p-4 z-20">
-                            <Button 
-                                size="sm" 
-                                className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-lg" 
-                                onClick={(e) => { 
-                                    e.stopPropagation(); 
-                                    router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`); 
+                            <Button
+                                size="sm"
+                                className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 shadow-md"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`);
                                 }}
                             >
-                                <BookOpen className="w-4 h-4 mr-2" /> {item.isCompleted ? "Re-read" : "Resume"}
+                                <BookOpen className="w-3 h-3 mr-2" /> {item.isCompleted ? "Re-read" : "Resume"}
                             </Button>
                         </div>
                         

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -1020,53 +1020,50 @@ function LibraryContent() {
                       </div>
 
                         <div className={`absolute inset-0 bg-black/80 transition-opacity flex-col items-center justify-center gap-1.5 p-3 z-20 pointer-events-none group-hover:pointer-events-auto ${isSelectionMode ? 'hidden' : 'hidden md:flex opacity-0 group-hover:opacity-100'}`}>
-                        <Button 
-                            variant="default" 
-                            size="sm" 
-                            className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold bg-primary hover:bg-primary/90 text-primary-foreground border-0 min-w-0 px-2" 
+                        <Button
+                            variant="default"
+                            size="sm"
+                            className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                             onClick={(e) => handleNavigate(e as any, item.path, navId)}
                             aria-label={`Open reader for ${item.name}`}
                         >
-                            {navigatingTo === navId ? <Loader2 className="w-3 h-3 mr-1.5 animate-spin shrink-0" /> : <BookOpen className="w-3 h-3 mr-1.5 shrink-0" />} 
-                            <span className="truncate">{navigatingTo === navId ? "Loading..." : "Read Series"}</span>
+                            {navigatingTo === navId ? <Loader2 className="w-3 h-3 animate-spin shrink-0" /> : <BookOpen className="w-3 h-3 shrink-0" />}
+                            <span>{navigatingTo === navId ? "Loading..." : "Read"}</span>
                         </Button>
-                        <div className="flex gap-1.5 w-full">
-                          <Button 
-                            variant="secondary" 
-                            size="sm" 
-                            className="h-10 sm:h-8 flex-1 shadow-lg font-bold px-1.5 min-w-0 flex items-center justify-center" 
+                        <div className="flex gap-1.5 w-full justify-center">
+                          <Button
+                            variant="secondary"
+                            size="icon-sm"
+                            className="shadow-md"
                             onClick={(e) => { e.preventDefault(); e.stopPropagation(); setTargetSeries(item); }}
                             title="Add to List"
                             aria-label={`Add ${item.name} to a reading list`}
                         >
-                            <ListPlus className="w-4 h-4 shrink-0" /> 
+                            <ListPlus className="w-4 h-4" />
                         </Button>
                         {isAdmin && (
-                            <Button 
-                                variant="secondary" 
-                                size="sm" 
-                                className="h-10 sm:h-8 flex-1 shadow-lg font-bold px-1.5 min-w-0 flex items-center justify-center" 
+                            <Button
+                                variant="secondary"
+                                size="icon-sm"
+                                className="shadow-md"
                                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); setEditing(item); }}
                                 title="Edit Metadata"
                                 aria-label={`Edit metadata for ${item.name}`}
                             >
-                                <Settings2 className="w-4 h-4 shrink-0" /> 
+                                <Settings2 className="w-4 h-4" />
                             </Button>
                             )}
-                        </div>
                         {isAdmin && (
-                            // --- NEW: Using the new explicit Metadata variables ---
-                            <Button aria-label={`Refresh cover art for ${item.name}`} variant="default" size="sm" className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold border-0 min-w-0 px-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); initiateRefreshMetadata(item.metadataId || item.cvId?.toString(), item.metadataSource || 'COMICVINE', item.path); }}>
-                                <RefreshCw className="w-3 h-3 mr-1.5 shrink-0" /> 
-                                <span className="truncate">Fetch Cover</span>
+                            <Button aria-label={`Refresh cover art for ${item.name}`} variant="secondary" size="icon-sm" className="shadow-md" onClick={(e) => { e.preventDefault(); e.stopPropagation(); initiateRefreshMetadata(item.metadataId || item.cvId?.toString(), item.metadataSource || 'COMICVINE', item.path); }} title="Refresh Cover">
+                                <RefreshCw className="w-4 h-4" />
                             </Button>
                         )}
                         {activeCollection !== "ALL" && (
-                            <Button aria-label={`Remove ${item.name} from current list`} variant="destructive" size="sm" className="h-10 sm:h-8 w-full shadow-lg text-xs sm:text-[10px] font-bold min-w-0 px-2" onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleRemoveFromCollection(item.id); }}>
-                                <Minus className="w-3 h-3 mr-1.5 shrink-0" /> 
-                                <span className="truncate">Remove</span>
+                            <Button aria-label={`Remove ${item.name} from current list`} variant="destructive" size="icon-sm" className="shadow-md" onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleRemoveFromCollection(item.id); }} title="Remove from List">
+                                <Minus className="w-4 h-4" />
                             </Button>
                         )}
+                        </div>
                       </div>
                   </Card>
                   <div 

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -21,6 +21,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useToast } from "@/components/ui/use-toast"
 import { copyText } from "@/lib/utils/clipboard"
+import { cn } from "@/lib/utils"
 import { Switch } from "@/components/ui/switch"
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -91,7 +92,7 @@ const LIST_TABLE_COMPONENTS: TableComponents<LibrarySeries, ListRowContext> = {
     return (
       <tr
         {...props}
-        className={`transition-colors group ${selectionMode ? 'cursor-pointer hover:bg-muted ' + (isSelected ? 'bg-primary/10' : '') : 'hover:bg-muted/50'}`}
+        className={cn("transition-colors group", selectionMode ? cn("cursor-pointer hover:bg-muted", isSelected && "bg-primary/10") : "hover:bg-muted/50")}
         onClick={() => { if (selectionMode && item.id) context!.toggleSeriesSelection(item.id); }}
       />
     );
@@ -736,16 +737,16 @@ function LibraryContent() {
         <h1 className="text-3xl font-bold flex items-center gap-2 text-foreground">Library</h1>
         <div className="flex flex-wrap items-center gap-2 sm:gap-4 w-full sm:w-auto justify-between sm:justify-end">
             <div className="flex bg-muted p-1 rounded-md shrink-0 shadow-inner border border-border overflow-x-auto max-w-full" role="tablist" aria-label="Library Section Filters">
-                <Button role="tab" aria-selected={libraryFilter === 'ALL'} variant={libraryFilter === 'ALL' ? 'default' : 'ghost'} size="sm" className={`h-8 sm:h-7 px-3 text-xs ${libraryFilter === 'ALL' ? 'shadow-sm bg-background text-foreground' : 'text-muted-foreground'}`} onClick={() => setLibraryFilter('ALL')}>All</Button>
-                <Button role="tab" aria-selected={libraryFilter === 'COMICS'} variant={libraryFilter === 'COMICS' ? 'default' : 'ghost'} size="sm" className={`h-8 sm:h-7 px-3 text-xs ${libraryFilter === 'COMICS' ? 'shadow-sm bg-background text-foreground' : 'text-muted-foreground'}`} onClick={() => setLibraryFilter('COMICS')}>Comics</Button>
-                <Button role="tab" aria-selected={libraryFilter === 'MANGA'} variant={libraryFilter === 'MANGA' ? 'default' : 'ghost'} size="sm" className={`h-8 sm:h-7 px-3 text-xs ${libraryFilter === 'MANGA' ? 'shadow-sm bg-background text-foreground' : 'text-muted-foreground'}`} onClick={() => setLibraryFilter('MANGA')}>Manga</Button>
+                <Button role="tab" aria-selected={libraryFilter === 'ALL'} variant={libraryFilter === 'ALL' ? 'default' : 'ghost'} size="sm" className={cn("h-8 sm:h-7 px-3 text-xs", libraryFilter === 'ALL' ? "shadow-sm bg-background text-foreground" : "text-muted-foreground")} onClick={() => setLibraryFilter('ALL')}>All</Button>
+                <Button role="tab" aria-selected={libraryFilter === 'COMICS'} variant={libraryFilter === 'COMICS' ? 'default' : 'ghost'} size="sm" className={cn("h-8 sm:h-7 px-3 text-xs", libraryFilter === 'COMICS' ? "shadow-sm bg-background text-foreground" : "text-muted-foreground")} onClick={() => setLibraryFilter('COMICS')}>Comics</Button>
+                <Button role="tab" aria-selected={libraryFilter === 'MANGA'} variant={libraryFilter === 'MANGA' ? 'default' : 'ghost'} size="sm" className={cn("h-8 sm:h-7 px-3 text-xs", libraryFilter === 'MANGA' ? "shadow-sm bg-background text-foreground" : "text-muted-foreground")} onClick={() => setLibraryFilter('MANGA')}>Manga</Button>
                 {isAdmin && (
-                    <Button role="tab" aria-selected={libraryFilter === 'UNMATCHED'} variant={libraryFilter === 'UNMATCHED' ? 'default' : 'ghost'} size="sm" className={`h-8 sm:h-7 px-3 text-xs ${libraryFilter === 'UNMATCHED' ? 'shadow-sm bg-orange-500 hover:bg-orange-600 text-white' : 'text-orange-500 hover:text-orange-600'}`} onClick={() => setLibraryFilter('UNMATCHED')}>
+                    <Button role="tab" aria-selected={libraryFilter === 'UNMATCHED'} variant={libraryFilter === 'UNMATCHED' ? 'default' : 'ghost'} size="sm" className={cn("h-8 sm:h-7 px-3 text-xs", libraryFilter === 'UNMATCHED' ? "shadow-sm bg-orange-500 hover:bg-orange-600 text-white" : "text-orange-500 hover:text-orange-600")} onClick={() => setLibraryFilter('UNMATCHED')}>
                         Unmatched
                     </Button>
                 )}
                 {isAdmin && (
-                    <Button role="tab" aria-selected={libraryFilter === 'PENDING'} variant={libraryFilter === 'PENDING' ? 'default' : 'ghost'} size="sm" className={`h-8 sm:h-7 px-3 text-xs ${libraryFilter === 'PENDING' ? 'shadow-sm bg-blue-500 hover:bg-blue-600 text-white' : 'text-blue-500 hover:text-blue-600'}`} onClick={() => setLibraryFilter('PENDING')}>
+                    <Button role="tab" aria-selected={libraryFilter === 'PENDING'} variant={libraryFilter === 'PENDING' ? 'default' : 'ghost'} size="sm" className={cn("h-8 sm:h-7 px-3 text-xs", libraryFilter === 'PENDING' ? "shadow-sm bg-blue-500 hover:bg-blue-600 text-white" : "text-blue-500 hover:text-blue-600")} onClick={() => setLibraryFilter('PENDING')}>
                         Pending
                     </Button>
                 )}
@@ -755,7 +756,7 @@ function LibraryContent() {
                 <Button aria-label="Browse all individual issues by release date" variant="outline" size="sm" onClick={() => router.push('/library/issues')} className="h-10 sm:h-9 border-border">
                     <CalendarDays className="w-4 h-4 mr-2" /> All Issues
                 </Button>
-                <Button aria-label={isSelectionMode ? "Cancel series selection" : "Enter series selection mode"} variant={isSelectionMode ? "secondary" : "outline"} size="sm" onClick={() => { setIsSelectionMode(!isSelectionMode); setSelectedSeries(new Set()); }} className={`h-10 sm:h-9 ${isSelectionMode ? "bg-primary/20 text-primary border-primary/50 hover:bg-primary/30" : "border-border"}`}>
+                <Button aria-label={isSelectionMode ? "Cancel series selection" : "Enter series selection mode"} variant={isSelectionMode ? "secondary" : "outline"} size="sm" onClick={() => { setIsSelectionMode(!isSelectionMode); setSelectedSeries(new Set()); }} className={cn("h-10 sm:h-9", isSelectionMode ? "bg-primary/20 text-primary border-primary/50 hover:bg-primary/30" : "border-border")}>
                     <CheckSquare className="w-4 h-4 mr-2" /> {isSelectionMode ? "Cancel Select" : "Select"}
                 </Button>
                 <Button aria-label="Scan library folders for new files" onClick={handleRefresh} disabled={loading || isRefreshing} variant="outline" size="sm" className="h-10 sm:h-9 border-border">
@@ -804,10 +805,10 @@ function LibraryContent() {
                   </Select>
                   
                   <div className="flex items-center gap-1 border border-border rounded-md p-1 bg-background shadow-sm shrink-0">
-                    <Button aria-label="Grid view mode" variant="ghost" size="icon" className={`h-8 w-8 sm:h-7 sm:w-7 transition-colors ${viewMode === 'grid' ? 'bg-primary/20 text-primary hover:bg-primary/30' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`} onClick={() => toggleViewMode('grid')}>
+                    <Button aria-label="Grid view mode" variant="ghost" size="icon" className={cn("h-8 w-8 sm:h-7 sm:w-7 transition-colors", viewMode === 'grid' ? "bg-primary/20 text-primary hover:bg-primary/30" : "text-muted-foreground hover:bg-muted hover:text-foreground")} onClick={() => toggleViewMode('grid')}>
                         <LayoutGrid className="w-4 h-4" />
                     </Button>
-                    <Button aria-label="List view mode" variant="ghost" size="icon" className={`h-8 w-8 sm:h-7 sm:w-7 transition-colors ${viewMode === 'list' ? 'bg-primary/20 text-primary hover:bg-primary/30' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`} onClick={() => toggleViewMode('list')}>
+                    <Button aria-label="List view mode" variant="ghost" size="icon" className={cn("h-8 w-8 sm:h-7 sm:w-7 transition-colors", viewMode === 'list' ? "bg-primary/20 text-primary hover:bg-primary/30" : "text-muted-foreground hover:bg-muted hover:text-foreground")} onClick={() => toggleViewMode('list')}>
                         <List className="w-4 h-4" />
                     </Button>
                 </div>
@@ -817,8 +818,8 @@ function LibraryContent() {
           {/* Mobile: 2-up grid so the dropdowns don't stack one-per-row; sm+: original wrapped flex row */}
           <div className="grid grid-cols-2 gap-3 sm:flex sm:flex-row sm:flex-wrap sm:items-center w-full">
               <div className="col-span-2 flex gap-2 w-full sm:w-auto overflow-x-auto pb-1 sm:pb-0 max-w-full">
-                  <Button aria-label="Filter by favorite status" variant={showFavoritesOnly ? "default" : "outline"} className={`shrink-0 h-10 sm:h-9 font-bold shadow-sm ${showFavoritesOnly ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'bg-background border-border text-muted-foreground hover:text-primary'}`} onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}>
-                      <Heart className={`w-4 h-4 ${showFavoritesOnly ? 'fill-current' : ''} sm:mr-2`} />
+                  <Button aria-label="Filter by favorite status" variant={showFavoritesOnly ? "default" : "outline"} className={cn("shrink-0 h-10 sm:h-9 font-bold shadow-sm", showFavoritesOnly ? "bg-primary hover:bg-primary/90 text-primary-foreground border-0" : "bg-background border-border text-muted-foreground hover:text-primary")} onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}>
+                      <Heart className={cn("w-4 h-4", showFavoritesOnly && "fill-current", "sm:mr-2")} />
                       <span className="hidden sm:inline-block">Favorites</span>
                   </Button>
                   
@@ -828,7 +829,7 @@ function LibraryContent() {
                   </Button>
 
                   {isAdmin && (
-                      <Button aria-label="Filter monitored series" variant={monitoredFilter ? "default" : "outline"} className={`shrink-0 h-10 sm:h-9 font-bold shadow-sm ${monitoredFilter ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'bg-background border-border text-muted-foreground hover:text-primary'}`} onClick={() => setMonitoredFilter(!monitoredFilter)}>
+                      <Button aria-label="Filter monitored series" variant={monitoredFilter ? "default" : "outline"} className={cn("shrink-0 h-10 sm:h-9 font-bold shadow-sm", monitoredFilter ? "bg-primary hover:bg-primary/90 text-primary-foreground border-0" : "bg-background border-border text-muted-foreground hover:text-primary")} onClick={() => setMonitoredFilter(!monitoredFilter)}>
                           <Activity className={`w-4 h-4 sm:mr-2`} />
                           <span className="hidden sm:inline-block">Monitored</span>
                       </Button>
@@ -837,7 +838,7 @@ function LibraryContent() {
 
               <div className="flex items-center gap-1 w-full sm:w-auto flex-1 sm:flex-none">
                   <Select value={activeCollection} onValueChange={setActiveCollection}>
-                      <SelectTrigger aria-label="Filter by reading list" className={`w-full sm:w-[150px] h-10 sm:h-9 shadow-sm ${activeCollection !== "ALL" ? "bg-primary/10 text-primary border-primary/30 font-bold" : "bg-background border-border"}`}>
+                      <SelectTrigger aria-label="Filter by reading list" className={cn("w-full sm:w-[150px] h-10 sm:h-9 shadow-sm", activeCollection !== "ALL" ? "bg-primary/10 text-primary border-primary/30 font-bold" : "bg-background border-border")}>
                           <div className="flex items-center gap-2 truncate"><Layers className="w-3 h-3 shrink-0"/> <SelectValue placeholder="Reading Lists" /></div>
                       </SelectTrigger>
                       <SelectContent className="bg-popover border-border">
@@ -956,7 +957,7 @@ function LibraryContent() {
               const navId = item.id || item.path;
               return (
                 <div className="group flex flex-col space-y-2 relative">
-                  <Card className={`aspect-[2/3] overflow-hidden shadow-sm transition-all p-0 relative flex flex-col ${isSelectionMode ? (isSelected ? 'border-4 border-primary scale-95' : 'border-2 border-border cursor-pointer') : 'border-border group-hover:shadow-md cursor-pointer bg-background'}`}>
+                  <Card className={cn("aspect-[2/3] overflow-hidden shadow-sm transition-all p-0 relative flex flex-col", isSelectionMode ? (isSelected ? "border-4 border-primary scale-95" : "border-2 border-border cursor-pointer") : "border-border group-hover:shadow-md cursor-pointer bg-background")}>
                       {isSelectionMode && item.id && (<div className="absolute top-2 left-2 z-40 bg-black/50 backdrop-blur-sm rounded p-1 pointer-events-none">{isSelected ? <CheckSquare className="w-6 h-6 text-primary" /> : <Square className="w-6 h-6 text-white/80" />}</div>)}
                       
                       <div 
@@ -978,7 +979,7 @@ function LibraryContent() {
                                 src={item.cover} 
                                 alt={`Cover art for ${item.name}`} 
                                 loading="lazy" 
-                                className={`object-cover w-full h-full relative z-10 transition-opacity ${isCompleted ? 'opacity-60' : ''}`} 
+                                className={cn("object-cover w-full h-full relative z-10 transition-opacity", isCompleted && "opacity-60")} 
                                 onError={(e) => { e.currentTarget.style.display = 'none'; }} 
                               />
                           )}
@@ -1002,8 +1003,8 @@ function LibraryContent() {
                           )}
                           {!isSelectionMode && (
                               <div className="absolute top-1.5 right-1.5 z-30">
-                                  <button aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`} onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleFavorite(item.id, item.isFavorite); }} className={`h-8 w-8 sm:h-6 sm:w-6 rounded-full bg-black/50 backdrop-blur-md flex items-center justify-center transition-all ${item.isFavorite ? 'text-primary opacity-100' : 'text-white/70 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:text-primary'}`}>
-                                      <Heart className={`w-4 h-4 sm:w-3.5 sm:h-3.5 ${item.isFavorite ? 'fill-current' : ''}`} />
+                                  <button aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`} onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleFavorite(item.id, item.isFavorite); }} className={cn("h-8 w-8 sm:h-6 sm:w-6 rounded-full bg-black/50 backdrop-blur-md flex items-center justify-center transition-all", item.isFavorite ? "text-primary opacity-100" : "text-white/70 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:text-primary")}>
+                                      <Heart className={cn("w-4 h-4 sm:w-3.5 sm:h-3.5", item.isFavorite && "fill-current")} />
                                   </button>
                               </div>
                           )}
@@ -1019,7 +1020,7 @@ function LibraryContent() {
                           {progress > 0 && !isCompleted && (<div className="absolute bottom-0 left-0 right-0 h-2.5 bg-black/80 z-10 border-t border-black/40"><div className="h-full bg-primary transition-all duration-500 shadow-sm shadow-primary/50" style={{ width: `${progress}%` }} /></div>)}
                       </div>
 
-                        <div className={`absolute inset-0 bg-black/80 transition-opacity flex-col items-center justify-center gap-1.5 p-3 z-20 pointer-events-none group-hover:pointer-events-auto ${isSelectionMode ? 'hidden' : 'hidden md:flex opacity-0 group-hover:opacity-100'}`}>
+                        <div className={cn("absolute inset-0 bg-black/80 transition-opacity flex-col items-center justify-center gap-1.5 p-3 z-20 pointer-events-none group-hover:pointer-events-auto", isSelectionMode ? "hidden" : "hidden md:flex opacity-0 group-hover:opacity-100")}>
                         <Button
                             variant="default"
                             size="sm"
@@ -1079,7 +1080,7 @@ function LibraryContent() {
                       }}
                   >
                       <div className="flex items-start justify-between gap-1 cursor-pointer hover:underline">
-                          <h3 className={`text-[12px] sm:text-[11px] font-bold truncate leading-tight ${isCompleted ? 'text-muted-foreground' : 'text-foreground'}`} title={item.name}>{item.name}</h3>
+                          <h3 className={cn("text-[12px] sm:text-[11px] font-bold truncate leading-tight", isCompleted ? "text-muted-foreground" : "text-foreground")} title={item.name}>{item.name}</h3>
                       </div>
                       <p className="text-[10px] sm:text-[9px] text-muted-foreground mt-0.5 truncate" title={item.publisher || 'Unknown'}>{item.publisher || 'Unknown'} • {item.year || '????'}</p>
                   </div>
@@ -1129,14 +1130,14 @@ function LibraryContent() {
                                       src={item.cover} 
                                       alt={`Cover art for ${item.name}`} 
                                       loading="lazy" 
-                                      className={`w-full h-full object-cover relative z-10 transition-opacity ${isCompleted ? 'opacity-60' : ''}`} 
+                                      className={cn("w-full h-full object-cover relative z-10 transition-opacity", isCompleted && "opacity-60")} 
                                       onError={(e) => { e.currentTarget.style.display = 'none'; }}
                                     />
                                 )}
                                 {isCompleted && (<div className="absolute inset-0 flex items-center justify-center bg-green-500/20 z-20"><Check className="w-4 h-4 text-green-500 font-bold"/></div>)}
                             </div>
                         </td>
-                        <td className={`px-4 py-3 font-bold ${isCompleted ? 'text-muted-foreground' : 'text-foreground'}`}>
+                        <td className={cn("px-4 py-3 font-bold", isCompleted ? "text-muted-foreground" : "text-foreground")}>
                             <div className="flex items-center gap-2">
                                 {isSelectionMode ? (<span>{item.name}</span>) : (
                                     <button 
@@ -1148,7 +1149,7 @@ function LibraryContent() {
                                         {navigatingTo === navId && <Loader2 className="w-3 h-3 animate-spin text-primary" />}
                                     </button>
                                 )}
-                                {!isSelectionMode && (<button aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`} onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleFavorite(item.id, item.isFavorite); }} className={`transition-colors focus:outline-none p-2 -m-2 ${item.isFavorite ? 'text-primary' : 'text-muted-foreground/50 hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100'}`}><Heart className={`w-4 h-4 sm:w-3.5 sm:h-3.5 ${item.isFavorite ? 'fill-current' : ''}`} /></button>)}
+                                {!isSelectionMode && (<button aria-label={item.isFavorite ? `Remove ${item.name} from favorites` : `Add ${item.name} to favorites`} onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleFavorite(item.id, item.isFavorite); }} className={cn("transition-colors focus:outline-none p-2 -m-2", item.isFavorite ? "text-primary" : "text-muted-foreground/50 hover:text-primary opacity-100 sm:opacity-0 sm:group-hover:opacity-100")}><Heart className={cn("w-4 h-4 sm:w-3.5 sm:h-3.5", item.isFavorite && "fill-current")} /></button>)}
                                 
                                 {item.monitored && (
                                     <Badge className="shrink-0 bg-emerald-600 hover:bg-emerald-600 text-white border-0 text-[9px] px-1.5 h-4 uppercase tracking-wider flex items-center">
@@ -1216,11 +1217,11 @@ function LibraryContent() {
               <span aria-live="polite" className="font-black whitespace-nowrap min-w-[60px] sm:min-w-[100px] text-center text-sm sm:text-base shrink-0">{selectedSeries.size} Selected</span>
               
               <div className="flex gap-2 shrink-0">
-                <Button aria-label="Mark selected series as unread" size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedSeries.size > 0 ? 'text-primary hover:bg-muted border-primary/50' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress('UNREAD')}>
+                <Button aria-label="Mark selected series as unread" size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedSeries.size > 0 ? "text-primary hover:bg-muted border-primary/50" : "bg-muted text-muted-foreground cursor-not-allowed border-border")} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress('UNREAD')}>
                     <EyeOff className="w-4 h-4 sm:mr-2" /> <span className="hidden sm:inline">Mark Unread</span>
                 </Button>
                 
-                <Button aria-label="Add selected series to a reading list" size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedSeries.size > 0 ? 'text-primary hover:bg-muted border-primary/50' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => setBulkListModalOpen(true)}>
+                <Button aria-label="Add selected series to a reading list" size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedSeries.size > 0 ? "text-primary hover:bg-muted border-primary/50" : "bg-muted text-muted-foreground cursor-not-allowed border-border")} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => setBulkListModalOpen(true)}>
                     <ListPlus className="w-4 h-4 sm:mr-2" /> <span className="hidden sm:inline">Add to List</span>
                 </Button>
 
@@ -1273,7 +1274,7 @@ function LibraryContent() {
                 )}
 
                 {isAdmin && (
-                  <Button aria-label="Delete selected series" size="sm" className={`h-10 sm:h-8 shadow-sm font-bold ml-1 sm:ml-2 transition-all ${selectedSeries.size > 0 ? 'bg-red-600 hover:bg-red-700 text-white' : 'bg-muted text-muted-foreground cursor-not-allowed'}`} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => setBulkDeleteModalOpen(true)}>
+                  <Button aria-label="Delete selected series" size="sm" className={cn("h-10 sm:h-8 shadow-sm font-bold ml-1 sm:ml-2 transition-all", selectedSeries.size > 0 ? "bg-red-600 hover:bg-red-700 text-white" : "bg-muted text-muted-foreground cursor-not-allowed")} disabled={selectedSeries.size === 0 || isBulkProcessing} onClick={() => setBulkDeleteModalOpen(true)}>
                       <Trash2 className="w-4 h-4" />
                   </Button>
                 )}

--- a/src/app/library/series/page.tsx
+++ b/src/app/library/series/page.tsx
@@ -1688,20 +1688,20 @@ function SeriesContent() {
                                     <div className="flex flex-col justify-between flex-1 py-1 min-w-0">
                                       <div><h5 className={`font-bold text-base line-clamp-2 leading-tight ${isRead ? 'text-muted-foreground' : 'text-foreground'}`}>{issue.name}</h5>{issue.parsedNum !== null && <span className="text-[10px] mt-1 font-black text-muted-foreground uppercase tracking-widest">Issue #{issue.parsedNum}</span>}</div>
                                       <div className="flex flex-wrap items-center gap-1.5 mt-3">
-                                        <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="flex-1 h-9 text-[11px] font-black uppercase tracking-wider min-w-[70px]" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
+                                        <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="flex-1 font-bold shadow-md min-w-[70px]" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
                                             <Link href={`/reader?path=${encodeURIComponent(issue.fullPath)}&series=${encodeURIComponent(folderPath || '')}`}>
                                                 {getReadButtonLabel(issue)}
                                             </Link>
                                         </Button>
-                                        
+
                                         {!isSelectionMode && (
-                                            <Button size="sm" variant="ghost" className="h-9 w-9 p-0 text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
+                                            <Button size="icon-sm" variant="ghost" className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
                                                 {isRead ? <EyeOff className="w-4 h-4" /> : <CheckCircle2 className="w-4 h-4" />}
                                             </Button>
                                         )}
 
                                         {canDownload && !isSelectionMode && (
-                                            <Button size="sm" variant="secondary" className="h-9 w-9 p-0 flex items-center justify-center bg-muted hover:bg-muted/80 text-foreground border-border shrink-0" asChild onClick={(e) => e.stopPropagation()}>
+                                            <Button size="icon-sm" variant="secondary" className="shrink-0" asChild onClick={(e) => e.stopPropagation()}>
                                                 <a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download>
                                                     <Download className="w-4 h-4" />
                                                 </a>
@@ -1709,7 +1709,7 @@ function SeriesContent() {
                                         )}
 
                                         {isAdmin && !isSelectionMode && (
-                                            <Button size="sm" variant="ghost" className="h-9 w-9 p-0 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0 border border-transparent hover:border-red-200 dark:hover:border-red-900/50" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
+                                            <Button size="icon-sm" variant="ghost" className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}
@@ -1772,18 +1772,18 @@ function SeriesContent() {
                                                   <td className="px-4 py-3 text-right">
                                                       <div className="flex items-center justify-end gap-2">
                                                           {!isSelectionMode && (
-                                                              <Button size="sm" variant="ghost" className="h-8 w-8 p-0 text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
+                                                              <Button size="icon-sm" variant="ghost" className="text-muted-foreground hover:text-foreground hover:bg-muted shrink-0" onClick={(e) => { e.stopPropagation(); handleToggleRead(issue, !isRead); }} title={isRead ? "Mark Unread" : "Mark Read"}>
                                                                   {isRead ? <EyeOff className="w-4 h-4" /> : <CheckCircle2 className="w-4 h-4" />}
                                                               </Button>
                                                           )}
-                                                          <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="h-8 text-[11px] font-black uppercase tracking-wider" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
+                                                          <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="font-bold shadow-md" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
                                                               <Link href={`/reader?path=${encodeURIComponent(issue.fullPath)}&series=${encodeURIComponent(folderPath || '')}`}>
                                                                   {getReadButtonLabel(issue)}
                                                               </Link>
                                                           </Button>
-                                                          {canDownload && !isSelectionMode && <Button size="sm" variant="secondary" className="h-8 px-3 bg-muted hover:bg-muted/80 text-foreground border-border hidden sm:flex" asChild onClick={(e) => e.stopPropagation()}><a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download><Download className="w-4 h-4" /></a></Button>}
+                                                          {canDownload && !isSelectionMode && <Button size="icon-sm" variant="secondary" className="shrink-0 hidden sm:flex" asChild onClick={(e) => e.stopPropagation()}><a href={`/api/library/download?path=${encodeURIComponent(issue.fullPath)}`} download><Download className="w-4 h-4" /></a></Button>}
                                                           {isAdmin && !isSelectionMode && (
-                                                              <Button size="sm" variant="ghost" className="h-8 w-8 p-0 text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 hidden sm:flex" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
+                                                              <Button size="icon-sm" variant="ghost" className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20 shrink-0 hidden sm:flex" onClick={(e) => { e.stopPropagation(); setIssueToDelete(issue); setDeleteIssueModalOpen(true); }}>
                                                                   <Trash2 className="w-4 h-4" />
                                                               </Button>
                                                           )}
@@ -2010,7 +2010,7 @@ function SeriesContent() {
                               <div className="aspect-[2/3] bg-muted rounded-lg overflow-hidden border border-border relative shadow-sm">
                                   {item.image && <img src={getImageUrl(item.image) || ""} className="object-cover w-full h-full" alt="" />}
                                   <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                                      <Button size="sm" className="font-bold shadow-lg" disabled={isMatching}>
+                                      <Button size="sm" className="font-bold shadow-md" disabled={isMatching}>
                                           {isMatching ? <Loader2 className="animate-spin w-4 h-4" /> : "Select"}
                                       </Button>
                                   </div>

--- a/src/app/library/series/page.tsx
+++ b/src/app/library/series/page.tsx
@@ -24,6 +24,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Logger } from "@/lib/logger"
 import { getErrorMessage } from "@/lib/utils/error"
+import { cn } from "@/lib/utils"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import MetadataEditorModal from "@/components/metadata-editor-modal"
 
@@ -1162,7 +1163,7 @@ function SeriesContent() {
                           <div className="absolute bottom-2 right-2 z-30 flex items-center gap-1.5">
                               {activeIssue?.id ? (
                                   <>
-                                      <label className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/60 hover:bg-black/80 backdrop-blur-sm text-white text-[11px] font-bold cursor-pointer transition-colors shadow-lg ${coverUploading ? 'pointer-events-none opacity-70' : ''}`} title="Upload a custom cover for this issue">
+                                      <label className={cn("flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/60 hover:bg-black/80 backdrop-blur-sm text-white text-[11px] font-bold cursor-pointer transition-colors shadow-lg", coverUploading && "pointer-events-none opacity-70")} title="Upload a custom cover for this issue">
                                           <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" onChange={handleIssueCoverFile} disabled={coverUploading} />
                                           {coverUploading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
                                           <span>Cover</span>
@@ -1173,7 +1174,7 @@ function SeriesContent() {
                                   </>
                               ) : (
                                   <>
-                                      <label className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/60 hover:bg-black/80 backdrop-blur-sm text-white text-[11px] font-bold cursor-pointer transition-colors shadow-lg ${coverUploading ? 'pointer-events-none opacity-70' : ''}`} title="Upload a custom cover">
+                                      <label className={cn("flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-black/60 hover:bg-black/80 backdrop-blur-sm text-white text-[11px] font-bold cursor-pointer transition-colors shadow-lg", coverUploading && "pointer-events-none opacity-70")} title="Upload a custom cover">
                                           <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" onChange={handleCoverFile} disabled={coverUploading} />
                                           {coverUploading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
                                           <span>Cover</span>
@@ -1199,7 +1200,7 @@ function SeriesContent() {
                       {(seriesInfo.status || (seriesInfo.bookType && seriesInfo.bookType !== 'Print')) && (
                           <div className="flex gap-2">
                               {seriesInfo.status && (
-                                  <Badge variant={seriesInfo.status === 'Ongoing' ? 'default' : 'secondary'} className={`w-full flex-1 justify-center uppercase tracking-wider text-[10px] h-7 font-black ${seriesInfo.status === 'Ongoing' ? 'bg-green-600 hover:bg-green-700 text-white border-0' : 'bg-muted text-foreground border-border'}`}>
+                                  <Badge variant={seriesInfo.status === 'Ongoing' ? 'default' : 'secondary'} className={cn("w-full flex-1 justify-center uppercase tracking-wider text-[10px] h-7 font-black", seriesInfo.status === 'Ongoing' ? 'bg-green-600 hover:bg-green-700 text-white border-0' : 'bg-muted text-foreground border-border')}>
                                       {seriesInfo.status}
                                   </Badge>
                               )}
@@ -1211,7 +1212,7 @@ function SeriesContent() {
                           </div>
                       )}
                       {seriesInfo.id && (
-                          <Badge variant={seriesInfo.monitored ? 'default' : 'outline'} className={`w-full justify-center uppercase tracking-wider text-[10px] h-7 font-black ${seriesInfo.monitored ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'text-muted-foreground border-border'}`}>
+                          <Badge variant={seriesInfo.monitored ? 'default' : 'outline'} className={cn("w-full justify-center uppercase tracking-wider text-[10px] h-7 font-black", seriesInfo.monitored ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'text-muted-foreground border-border')}>
                               {seriesInfo.monitored ? 'Monitored' : 'Not Monitored'}
                           </Badge>
                       )}
@@ -1236,7 +1237,7 @@ function SeriesContent() {
                       </Button>
                   ) : (
                       <Button 
-                        className={`w-full font-black shadow-md ${activeIssue?.readProgress > 0 && !(activeIssue?.isRead || activeIssue?.readProgress >= 100) ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : ''}`} 
+                        className={cn("w-full font-black shadow-md", activeIssue?.readProgress > 0 && !(activeIssue?.isRead || activeIssue?.readProgress >= 100) && "bg-primary hover:bg-primary/90 text-primary-foreground border-0")} 
                         size="lg" 
                         disabled={!activeIssue || !activeIssue.fullPath} 
                         onClick={() => router.push(`/reader?path=${encodeURIComponent(activeIssue?.fullPath || '')}&series=${encodeURIComponent(folderPath || '')}`)}>
@@ -1245,8 +1246,8 @@ function SeriesContent() {
                       </Button>
                   )}
                   
-                  <Button variant={seriesInfo.isFavorite ? "default" : "outline"} className={`w-full font-bold transition-all ${seriesInfo.isFavorite ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'border-border hover:bg-muted'}`} onClick={toggleFavorite} disabled={!seriesInfo.id}>
-                      <Heart className={`w-4 h-4 mr-2 ${seriesInfo.isFavorite ? 'fill-current' : ''}`} /> Favorite
+                  <Button variant={seriesInfo.isFavorite ? "default" : "outline"} className={cn("w-full font-bold transition-all", seriesInfo.isFavorite ? 'bg-primary hover:bg-primary/90 text-primary-foreground border-0' : 'border-border hover:bg-muted')} onClick={toggleFavorite} disabled={!seriesInfo.id}>
+                      <Heart className={cn("w-4 h-4 mr-2", seriesInfo.isFavorite && "fill-current")} /> Favorite
                   </Button>
                   
                   {isAdmin && (
@@ -1263,7 +1264,7 @@ function SeriesContent() {
                   )}
 
                   {isAdmin && (
-                      <Button variant={seriesInfo.metadataId && seriesInfo.matchState !== 'UNMATCHED' ? "outline" : "default"} className={`w-full font-bold ${seriesInfo.metadataId && seriesInfo.matchState !== 'UNMATCHED' ? 'border-border hover:bg-muted text-foreground' : ''}`} onClick={() => { setSearchQuery(seriesInfo.name); setMatchModalOpen(true); }}>
+                      <Button variant={seriesInfo.metadataId && seriesInfo.matchState !== 'UNMATCHED' ? "outline" : "default"} className={cn("w-full font-bold", seriesInfo.metadataId && seriesInfo.matchState !== 'UNMATCHED' && 'border-border hover:bg-muted text-foreground')} onClick={() => { setSearchQuery(seriesInfo.name); setMatchModalOpen(true); }}>
                           <Search className="w-4 h-4 mr-2" /> {seriesInfo.metadataId && seriesInfo.matchState !== 'UNMATCHED' ? "Fix Match" : "Match Series"}
                       </Button>
                   )}
@@ -1320,7 +1321,7 @@ function SeriesContent() {
                         {isAdmin && (
                             <Button 
                                 variant="outline" 
-                                className={`w-full transition-all shadow-sm active:scale-95 ${missingIssues.length > 0 ? 'bg-primary/10 text-primary border-primary/30 hover:bg-primary/20' : 'opacity-50 grayscale cursor-not-allowed font-bold'}`}
+                                className={cn("w-full transition-all shadow-sm active:scale-95", missingIssues.length > 0 ? 'bg-primary/10 text-primary border-primary/30 hover:bg-primary/20' : 'opacity-50 grayscale cursor-not-allowed font-bold')}
                                 disabled={missingIssues.length === 0 || isBulkDownloading}
                                 onClick={handleDownloadAllMissing}
                             >
@@ -1495,7 +1496,7 @@ function SeriesContent() {
                           {[1, 2, 3, 4, 5].map(star => (
                               <Star 
                                   key={star} 
-                                  className={`w-6 h-6 cursor-pointer transition-colors ${userReview.rating >= star ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground'}`}
+                                  className={cn("w-6 h-6 cursor-pointer transition-colors", userReview.rating >= star ? 'fill-yellow-500 text-yellow-500' : 'text-muted-foreground')}
                                   onClick={() => setUserReview({ ...userReview, rating: star })}
                               />
                           ))}
@@ -1673,7 +1674,7 @@ function SeriesContent() {
                                             setActiveIssue(issue);
                                         }
                                     }}
-                                    className={`flex gap-4 p-4 bg-background border-2 rounded-xl shadow-sm relative overflow-hidden transition-all cursor-pointer ${isSelected ? (isSelectionMode ? 'border-primary ring-2 ring-primary/20 scale-[0.98]' : 'border-primary ring-4 ring-primary/10') : 'border-border hover:border-primary/50'}`}
+                                    className={cn("flex gap-4 p-4 bg-background border-2 rounded-xl shadow-sm relative overflow-hidden transition-all cursor-pointer", isSelected ? (isSelectionMode ? 'border-primary ring-2 ring-primary/20 scale-[0.98]' : 'border-primary ring-4 ring-primary/10') : 'border-border hover:border-primary/50')}
                                   >
                                     {isSelectionMode && (
                                        <div className="absolute top-2 left-2 z-40 bg-black/50 backdrop-blur-sm rounded p-1 pointer-events-none">
@@ -1681,12 +1682,12 @@ function SeriesContent() {
                                        </div>
                                     )}
                                     <div className="w-20 h-28 shrink-0 rounded-md overflow-hidden bg-muted border border-border relative">
-                                      {issue.coverUrl || seriesInfo.cover ? <img src={issue.coverUrl || seriesInfo.cover} onError={coverImgError(seriesInfo.cover)} className={`w-full h-full object-cover ${isRead ? 'opacity-60' : ''}`} alt="" /> : <ImageIcon className="w-8 h-8 m-auto mt-10 text-muted-foreground/50" />}
+                                      {issue.coverUrl || seriesInfo.cover ? <img src={issue.coverUrl || seriesInfo.cover} onError={coverImgError(seriesInfo.cover)} className={cn("w-full h-full object-cover", isRead && "opacity-60")} alt="" /> : <ImageIcon className="w-8 h-8 m-auto mt-10 text-muted-foreground/50" />}
                                       <div className="absolute top-1 right-1 z-10">{isRead ? <Badge className="bg-green-600 border-0 text-[9px] px-1 h-4"><Check className="w-3 h-3"/></Badge> : issue.readProgress > 0 ? <Badge className="bg-primary border-0 text-primary-foreground text-[9px] px-1 h-4">{Math.round(issue.readProgress)}%</Badge> : null}</div>
                                       {issue.readProgress > 0 && !isRead && <div className="absolute bottom-0 left-0 right-0 h-1.5 bg-black/50"><div className="h-full bg-primary" style={{ width: `${issue.readProgress}%` }} /></div>}
                                     </div>
                                     <div className="flex flex-col justify-between flex-1 py-1 min-w-0">
-                                      <div><h5 className={`font-bold text-base line-clamp-2 leading-tight ${isRead ? 'text-muted-foreground' : 'text-foreground'}`}>{issue.name}</h5>{issue.parsedNum !== null && <span className="text-[10px] mt-1 font-black text-muted-foreground uppercase tracking-widest">Issue #{issue.parsedNum}</span>}</div>
+                                      <div><h5 className={cn("font-bold text-base line-clamp-2 leading-tight", isRead ? 'text-muted-foreground' : 'text-foreground')}>{issue.name}</h5>{issue.parsedNum !== null && <span className="text-[10px] mt-1 font-black text-muted-foreground uppercase tracking-widest">Issue #{issue.parsedNum}</span>}</div>
                                       <div className="flex flex-wrap items-center gap-1.5 mt-3">
                                         <Button size="sm" variant={isSelected && !isSelectionMode ? "default" : "outline"} className="flex-1 font-bold shadow-md min-w-[70px]" asChild onClick={(e) => { if (isSelectionMode) { e.preventDefault(); } else { e.stopPropagation(); } }}>
                                             <Link href={`/reader?path=${encodeURIComponent(issue.fullPath)}&series=${encodeURIComponent(folderPath || '')}`}>
@@ -1749,7 +1750,7 @@ function SeriesContent() {
                                                         setActiveIssue(issue);
                                                     }
                                                 }} 
-                                                className={`cursor-pointer transition-colors ${isSelected ? (isSelectionMode ? 'bg-primary/10' : 'bg-muted/50') : 'hover:bg-muted/50'}`}
+                                                className={cn("cursor-pointer transition-colors", isSelected ? (isSelectionMode ? 'bg-primary/10' : 'bg-muted/50') : 'hover:bg-muted/50')}
                                               >
                                                   {isSelectionMode && (
                                                       <td className="px-4 py-3 text-center">
@@ -1758,12 +1759,12 @@ function SeriesContent() {
                                                   )}
                                                   <td className="px-4 py-2">
                                                       <div className="w-10 h-14 bg-muted rounded overflow-hidden flex items-center justify-center shrink-0 border border-border relative">
-                                                          {issue.coverUrl || seriesInfo.cover ? <img src={issue.coverUrl || seriesInfo.cover} onError={coverImgError(seriesInfo.cover)} className={`w-full h-full object-cover ${isRead ? 'opacity-60' : ''}`} alt="" /> : <ImageIcon className="w-4 h-4 text-muted-foreground/50" />}
+                                                          {issue.coverUrl || seriesInfo.cover ? <img src={issue.coverUrl || seriesInfo.cover} onError={coverImgError(seriesInfo.cover)} className={cn("w-full h-full object-cover", isRead && "opacity-60")} alt="" /> : <ImageIcon className="w-4 h-4 text-muted-foreground/50" />}
                                                           {isRead && <div className="absolute inset-0 flex items-center justify-center bg-green-500/20 z-20"><Check className="w-4 h-4 text-green-500 font-bold"/></div>}
                                                       </div>
                                                   </td>
                                                   <td className="px-4 py-3 font-bold">
-                                                      <div className={`line-clamp-2 leading-tight ${isRead ? 'text-muted-foreground' : 'text-foreground'}`}>{issue.name}</div>
+                                                      <div className={cn("line-clamp-2 leading-tight", isRead ? 'text-muted-foreground' : 'text-foreground')}>{issue.name}</div>
                                                       {issue.parsedNum !== null && <div className="text-[10px] mt-1 font-black text-muted-foreground uppercase tracking-widest">Issue #{issue.parsedNum}</div>}
                                                   </td>
                                                   <td className="px-4 py-3 text-center">
@@ -1811,15 +1812,15 @@ function SeriesContent() {
                           <span className="font-black whitespace-nowrap min-w-[60px] sm:min-w-[100px] text-center text-sm sm:text-base shrink-0">{selectedIssues.size} Selected</span>
                           
                           <div className="flex gap-2 shrink-0">
-                              <Button size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress(true)}>
+                              <Button size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border')} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress(true)}>
                                   {isBulkProcessing ? <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" /> : <CheckCircle2 className="w-4 h-4 sm:mr-2" />} <span className="hidden sm:inline">Mark Read</span>
                               </Button>
-                              <Button size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress(false)}>
+                              <Button size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border')} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => handleBulkProgress(false)}>
                                   {isBulkProcessing ? <Loader2 className="w-4 h-4 sm:mr-2 animate-spin" /> : <EyeOff className="w-4 h-4 sm:mr-2" />} <span className="hidden sm:inline">Mark Unread</span>
                               </Button>
                               
                               {isAdmin && (
-                                  <Button size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => {
+                                  <Button size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border')} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => {
                                       // Populate local state with the exact objects selected
                                       const itemsToEdit = downloadedIssues.filter(i => selectedIssues.has(i.id)).map(i => ({
                                           id: i.id, number: i.parsedNum?.toString() || "", name: i.name || "", releaseDate: i.releaseDate || ""
@@ -1832,7 +1833,7 @@ function SeriesContent() {
                               )}
 
                               {isAdmin && (
-                                  <Button size="sm" variant="outline" className={`h-10 sm:h-8 shadow-sm font-bold transition-all ${selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border'}`} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => { setMoveTargetId(null); setMoveNewName(""); setMoveSearch(""); setMoveResults([]); setMoveDialogOpen(true); }} title="Move the selected issues to another series">
+                                  <Button size="sm" variant="outline" className={cn("h-10 sm:h-8 shadow-sm font-bold transition-all", selectedIssues.size > 0 ? 'text-foreground hover:bg-muted' : 'bg-muted text-muted-foreground cursor-not-allowed border-border')} disabled={selectedIssues.size === 0 || isBulkProcessing} onClick={() => { setMoveTargetId(null); setMoveNewName(""); setMoveSearch(""); setMoveResults([]); setMoveDialogOpen(true); }} title="Move the selected issues to another series">
                                       <FolderInput className="w-4 h-4 sm:mr-2" /> <span className="hidden sm:inline">Move</span>
                                   </Button>
                               )}
@@ -1884,7 +1885,7 @@ function SeriesContent() {
                                               const isRequesting = requestingIds.has(issue.id);
                                               const isAlreadyRequested = requestedIds.has(issue.id);
                                               return (
-                                                  <tr key={issue.id} onClick={() => setActiveIssue(issue)} className={`cursor-pointer transition-colors ${requestingIds.has(issue.id) ? 'opacity-50' : 'hover:bg-muted/50'}`}>
+                                                  <tr key={issue.id} onClick={() => setActiveIssue(issue)} className={cn("cursor-pointer transition-colors", requestingIds.has(issue.id) ? 'opacity-50' : 'hover:bg-muted/50')}>
                                                       <td className="px-4 py-2">
                                                           <div className="w-10 h-14 bg-muted rounded overflow-hidden flex items-center justify-center shrink-0 border border-border grayscale relative">
                                                               {issue.coverUrl || seriesInfo.cover ? <img src={issue.coverUrl || seriesInfo.cover} onError={coverImgError(seriesInfo.cover)} className="w-full h-full object-cover" alt="" /> : <ImageIcon className="w-4 h-4 text-muted-foreground/50" />}
@@ -1939,7 +1940,7 @@ function SeriesContent() {
                       {moveResults.length > 0 && (
                           <div className="mt-2 max-h-48 overflow-y-auto rounded-lg border border-border divide-y divide-border">
                               {moveResults.map((s) => (
-                                  <button key={s.id} type="button" onClick={() => { setMoveTargetId(s.id); setMoveNewName(""); }} className={`w-full text-left px-3 py-2 text-sm transition-colors ${moveTargetId === s.id ? 'bg-primary/10 text-primary font-bold' : 'hover:bg-muted'}`}>
+                                  <button key={s.id} type="button" onClick={() => { setMoveTargetId(s.id); setMoveNewName(""); }} className={cn("w-full text-left px-3 py-2 text-sm transition-colors", moveTargetId === s.id ? 'bg-primary/10 text-primary font-bold' : 'hover:bg-muted')}>
                                       {s.name}{s.year ? <span className="text-muted-foreground"> ({s.year})</span> : null}
                                   </button>
                               ))}

--- a/src/components/ContinueReading.tsx
+++ b/src/components/ContinueReading.tsx
@@ -99,7 +99,7 @@ export function ContinueReading() {
         {items.map((item) => (
             <div 
               key={item.id} 
-              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-all cursor-pointer border border-border snap-start"
+              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-[transform,box-shadow] duration-200 cursor-pointer border border-border snap-start"
               onClick={() => router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`)}
             >
               <DynamicCover 
@@ -110,20 +110,20 @@ export function ContinueReading() {
                   altName={item.seriesName}
               />
 
-              <div className="absolute bottom-0 left-0 w-full p-3 bg-gradient-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-300 pointer-events-none">
+              <div className="absolute bottom-0 left-0 w-full p-3 bg-linear-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-200 pointer-events-none">
                   <div className="flex justify-between items-end mb-1.5">
                       <p className="text-white font-bold text-xs truncate max-w-[70%] drop-shadow-md">{item.seriesName}</p>
                       <p className="text-white/90 text-[10px] font-mono drop-shadow-md">{item.percentage}%</p>
                   </div>
-                  <div className="w-full bg-white/30 h-1.5 rounded-full overflow-hidden backdrop-blur-sm">
+                  <div className="w-full bg-white/30 h-1.5 rounded-full overflow-hidden backdrop-blur-xs">
                       <div 
-                          className="bg-primary h-full rounded-full transition-all duration-500 shadow-sm shadow-primary/50" 
+                          className="bg-primary h-full rounded-full transition-[width] duration-300 ease-out shadow-sm shadow-primary/50" 
                           style={{ width: `${item.percentage}%` }}
                       />
                   </div>
               </div>
 
-              <div className="absolute inset-0 bg-gradient-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
+              <div className="absolute inset-0 bg-linear-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.seriesName}</h3>
                   <p className="text-white/80 text-xs mb-1 drop-shadow-md">Issue #{item.issueNumber}</p>
                   

--- a/src/components/ContinueReading.tsx
+++ b/src/components/ContinueReading.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { BookOpen, Image as ImageIcon, X, ArrowRight } from "lucide-react"; 
+import { BookOpen, Image as ImageIcon, RotateCcw, ArrowRight } from "lucide-react"; 
 import { Button } from "@/components/ui/button";
 import Link from "next/link"; 
 import { Logger } from "@/lib/logger";
@@ -90,7 +90,7 @@ export function ContinueReading() {
         <h2 className="text-2xl font-bold tracking-tight text-foreground">Jump Back In</h2>
         <Button asChild variant="outline" size="sm" className="border-primary/50 text-primary hover:bg-primary/10 group font-bold hidden sm:flex">
             <Link href="/library/history">
-                View History <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>History</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>
@@ -129,22 +129,22 @@ export function ContinueReading() {
                   
                   <Button 
                       size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/reader?path=${encodeURIComponent(item.filePath)}&series=${encodeURIComponent(item.seriesPath)}`);
                       }}
                   >
-                      <BookOpen className="w-3 h-3 mr-2" /> Resume
+                      <BookOpen className="w-3 h-3 shrink-0" /> <span>Resume</span>
                   </Button>
 
-                  <Button 
-                      variant="secondary" 
-                      size="sm" 
-                      className="w-full font-bold shadow-md" 
+                  <Button
+                      variant="secondary"
+                      size="sm"
+                      className="w-full min-w-0 font-bold shadow-md"
                       onClick={(e) => handleMarkUnread(e, item.id)}
                   >
-                      <X className="w-3 h-3 mr-1" /> Mark Unread
+                      <RotateCcw className="w-3 h-3 shrink-0" /> <span>Unread</span>
                   </Button>
               </div>
             </div>
@@ -154,7 +154,7 @@ export function ContinueReading() {
       <div className="sm:hidden pt-2">
         <Button asChild variant="outline" className="w-full border-primary/50 text-primary hover:bg-primary/10 group font-bold">
             <Link href="/library/history">
-                View History <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>History</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>

--- a/src/components/comic-grid.tsx
+++ b/src/components/comic-grid.tsx
@@ -322,7 +322,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                 </div>
                 
                 <div className="absolute inset-0 hidden sm:flex opacity-0 group-hover:opacity-100 transition-opacity items-center justify-center z-40 pointer-events-none">
-                  <Button size="sm" className="font-bold shadow-lg bg-primary hover:bg-primary/90 text-primary-foreground pointer-events-auto transition-transform group-hover:scale-110" tabIndex={-1}>Details</Button>
+                  <Button size="sm" className="font-bold shadow-md pointer-events-auto transition-transform group-hover:scale-110" tabIndex={-1}>Details</Button>
                 </div>
             </div>
           )})}

--- a/src/components/comic-grid.tsx
+++ b/src/components/comic-grid.tsx
@@ -14,6 +14,7 @@ import Link from "next/link"
 import { Search as SearchIcon } from "lucide-react"
 import { InteractiveSearchModal } from "./interactive-search-modal"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
 
 interface Comic {
   id: number;
@@ -285,7 +286,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                 key={comic.id}
                 role="button"
                 tabIndex={0}
-                className="text-left w-full group relative aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-105 transition-all cursor-pointer border border-border focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none" 
+                className="text-left w-full group relative aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-105 transition-[transform,box-shadow] duration-200 ease-out cursor-pointer border border-border focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none" 
                 onClick={() => setSelectedComic(comic)}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -314,15 +315,15 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                 {issueStatus === 'UNRELEASED' && (<div className="absolute top-2 left-2 bg-purple-500 text-white rounded-full p-1 shadow-lg z-30" title="Unreleased"><Clock className="w-4 h-4 sm:w-3 sm:h-3" /></div>)}
                 {(!issueStatus && comic.issueNumber && comic.isReleased === false) && (<div className="absolute top-2 left-2 bg-purple-500/80 text-white rounded-full p-1 shadow-lg z-30" title="Unreleased"><Clock className="w-4 h-4 sm:w-3 sm:h-3" /></div>)}
 
-                <div className="absolute inset-0 bg-black/40 hidden sm:block opacity-0 group-hover:opacity-100 transition-opacity z-10 pointer-events-none" />
+                <div className="absolute inset-0 bg-black/40 hidden sm:block opacity-0 group-hover:opacity-100 transition-opacity duration-200 z-10 pointer-events-none" />
 
-                <div className="absolute inset-0 bg-gradient-to-t from-black/95 via-black/40 to-transparent opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity flex flex-col justify-end p-2 pb-3 text-center gap-0.5 z-30 pointer-events-none">
+                <div className="absolute inset-0 bg-linear-to-t from-black/95 via-black/40 to-transparent opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200 flex flex-col justify-end p-2 pb-3 text-center gap-0.5 z-30 pointer-events-none">
                     <h3 className="text-white font-bold text-xs sm:text-sm line-clamp-2 leading-tight drop-shadow-md">{comic.name}</h3>
                     <p className="text-primary font-bold text-[10px] sm:text-[11px] drop-shadow-md uppercase tracking-wider">{comic.year}</p>
                 </div>
                 
-                <div className="absolute inset-0 hidden sm:flex opacity-0 group-hover:opacity-100 transition-opacity items-center justify-center z-40 pointer-events-none">
-                  <Button size="sm" className="font-bold shadow-md pointer-events-auto transition-transform group-hover:scale-110" tabIndex={-1}>Details</Button>
+                <div className="absolute inset-0 hidden sm:flex opacity-0 group-hover:opacity-100 transition-opacity duration-200 items-center justify-center z-40 pointer-events-none">
+                  <Button size="sm" className="font-bold shadow-md pointer-events-auto transition-transform duration-150 group-hover:scale-110" tabIndex={-1}>Details</Button>
                 </div>
             </div>
           )})}
@@ -344,11 +345,11 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-[280px_1fr] gap-8 mb-8">
                         <div className="space-y-5 flex flex-col items-center md:items-stretch">
-                            <div className="relative aspect-[2/3] w-[200px] md:w-[240px] mx-auto rounded-lg overflow-hidden border bg-muted shadow-md border-border transition-colors duration-300">
+                            <div className="relative aspect-[2/3] w-[200px] md:w-60 mx-auto rounded-lg overflow-hidden border bg-muted shadow-md border-border transition-colors duration-300">
                                 {selectedComic.image ? (
                                     <img src={selectedComic.image} alt={selectedComic.name} className="absolute inset-0 w-full h-full object-contain" />
                                 ) : (
-                                    <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30 transition-transform duration-300">
+                                    <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30">
                                         <ImageIcon className="w-12 h-12 mb-2" />
                                     </div>
                                 )}
@@ -375,21 +376,21 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                 <div className="flex flex-col gap-2.5 sm:gap-3 w-full max-w-[300px] mx-auto md:max-w-none mt-2">
                                     {/* VOLUME BUTTONS */}
                                     {loadingRelated ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal" variant="outline" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal" variant="outline" disabled>
                                             <Loader2 className="w-4 h-4 animate-spin shrink-0" /> <span className="leading-tight">Checking Library...</span>
                                         </Button>
                                     ) : volStatus === 'PENDING_APPROVAL' || volStatus === 'REQUESTED' ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal" variant="default" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal" variant="default" disabled>
                                             {volStatus === 'PENDING_APPROVAL' && <><Clock className="w-4 h-4 text-yellow-500 shrink-0" /> <span className="leading-tight">Pending Approval</span></>}
                                             {volStatus === 'REQUESTED' && <><Clock className="w-4 h-4 text-orange-500 shrink-0" /> <span className="leading-tight">Requested</span></>}
                                         </Button>
                                     ) : (isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" variant="outline" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" variant="outline" disabled>
                                             <FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">Up to Date</span>
                                         </Button>
                                     ) : (isAllAvailableOwned && volStatus === 'LIBRARY_UNMONITORED') ? (
                                         <Button 
-                                            className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold bg-blue-600 hover:bg-blue-700 text-white whitespace-normal" 
+                                            className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold bg-blue-600 hover:bg-blue-700 text-white whitespace-normal" 
                                             variant="default" 
                                             onClick={() => handleRequest(selectedComic.volumeId, seriesBaseName, selectedComic.image, selectedComic.year, 'volume', selectedComic.publisher || 'Unknown', true, undefined, undefined, true, (selectedComic as any).metadataSource || 'COMICVINE')} 
                                             disabled={requestingTarget === `vol-${selectedComic.volumeId}`}
@@ -400,7 +401,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                         </Button>
                                     ) : (
                                         <Button 
-                                            className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal ${isVolOwned ? 'bg-green-600 hover:bg-green-700 text-white' : ''}`} 
+                                            className={cn("w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal", isVolOwned && "bg-green-600 hover:bg-green-700 text-white")} 
                                             variant="default" 
                                             onClick={() => setMonitorPrompt({ id: selectedComic.volumeId, name: seriesBaseName, image: selectedComic.image, year: selectedComic.year, publisher: selectedComic.publisher || 'Unknown', directSource: undefined, metadataSource: (selectedComic as any).metadataSource || 'COMICVINE' })} 
                                             disabled={requestingTarget === `vol-${selectedComic.volumeId}`}
@@ -413,11 +414,11 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                       
                                       {/* ISSUE BUTTONS */}
                                       {(isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') ? (
-                                          <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
+                                          <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
                                               <FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">Up to Date</span>
                                           </Button>
                                       ) : issueStatus === 'PENDING_APPROVAL' || issueStatus === 'REQUESTED' || issueStatus === 'UNRELEASED' || isIssueOwned ? (
-                                          <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
+                                          <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
                                               {isIssueOwned && <><FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">In Library</span></>}
                                               {issueStatus === 'PENDING_APPROVAL' && <><Clock className="w-4 h-4 text-yellow-500 shrink-0" /> <span className="leading-tight">Pending Approval</span></>}
                                               {issueStatus === 'REQUESTED' && <><Clock className="w-4 h-4 text-orange-500 shrink-0" /> <span className="leading-tight">Requested</span></>}
@@ -425,7 +426,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                           </Button>
                                       ) : (
                                           <Button 
-                                             className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 whitespace-normal" 
+                                             className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 whitespace-normal" 
                                              variant="outline" 
                                              onClick={() => handleRequest(selectedComic.volumeId, selectedComic.isVolume ? seriesBaseName : selectedComic.name, selectedComic.image, selectedComic.year, 'issue', selectedComic.publisher, false, undefined, selectedComic.issueNumber, false, (selectedComic as any).metadataSource || 'COMICVINE')} 
                                              disabled={requestingTarget === `iss-${issueTargetName}`}
@@ -436,7 +437,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                       
                                       <Button 
                                         variant="outline" 
-                                        className="w-full gap-1.5 border-dashed shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" 
+                                        className="w-full gap-1.5 border-dashed shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" 
                                         onClick={() => setInteractiveQuery({ query: selectedComic.isVolume ? seriesBaseName : selectedComic.name, type: selectedComic.isVolume ? 'issue' : 'volume' })}
                                         disabled={(isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') || (!selectedComic.isVolume && isIssueOwned) || overallStatus === 'PENDING_APPROVAL' || overallStatus === 'REQUESTED'}
                                       >
@@ -586,7 +587,7 @@ export function ComicGrid({ title, type, refreshSignal = 0 }: Props) {
                                                             <ImageIcon className="w-6 h-6" />
                                                         </div>
                                                     )}
-                                                    <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none" />
+                                                    <div className="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none" />
                                                     
                                                     <div className="absolute bottom-1 left-2 z-20 text-white text-[11px] font-black truncate drop-shadow-md">#{issue.issueNumber}</div>
 

--- a/src/components/recently-added.tsx
+++ b/src/components/recently-added.tsx
@@ -38,7 +38,7 @@ export function RecentlyAdded() {
         {items.map((item) => (
             <div 
               key={item.id} 
-              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-all cursor-pointer border border-border snap-start"
+              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-[transform,box-shadow] duration-200 cursor-pointer border border-border snap-start"
               onClick={() => router.push(`/library/series?path=${encodeURIComponent(item.path)}`)}
             >
               {item.coverUrl ? (
@@ -49,7 +49,7 @@ export function RecentlyAdded() {
                   </div>
               )}
 
-              <div className="absolute bottom-0 left-0 w-full p-3 bg-gradient-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-300 pointer-events-none">
+              <div className="absolute bottom-0 left-0 w-full p-3 bg-linear-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-200 ease-out pointer-events-none">
                   <div className="flex flex-col mb-1.5">
                       <p className="text-white font-bold text-xs truncate drop-shadow-md">{item.name}</p>
                       <p className="text-white/80 text-[10px] font-medium drop-shadow-md mt-0.5">
@@ -58,7 +58,7 @@ export function RecentlyAdded() {
                   </div>
               </div>
 
-              <div className="absolute inset-0 bg-gradient-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
+              <div className="absolute inset-0 bg-linear-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-out hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   

--- a/src/components/recently-added.tsx
+++ b/src/components/recently-added.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Library, Image as ImageIcon, ArrowRight } from "lucide-react"; 
+import { Eye, Image as ImageIcon, ArrowRight } from "lucide-react"; 
 import { Button } from "@/components/ui/button";
 import Link from "next/link"; 
 
@@ -29,7 +29,7 @@ export function RecentlyAdded() {
         <h2 className="text-2xl font-bold tracking-tight text-foreground">Recently Added</h2>
         <Button asChild variant="outline" size="sm" className="border-primary/50 text-primary hover:bg-primary/10 group font-bold hidden sm:flex">
             <Link href="/library">
-                View Library <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>Library</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>
@@ -62,15 +62,15 @@ export function RecentlyAdded() {
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   
-                  <Button 
-                      size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                  <Button
+                      size="sm"
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/library/series?path=${encodeURIComponent(item.path)}`);
                       }}
                   >
-                      <Library className="w-3 h-3 mr-2" /> View Series
+                      <Eye className="w-3 h-3 shrink-0" /> <span>View</span>
                   </Button>
               </div>
             </div>
@@ -80,7 +80,7 @@ export function RecentlyAdded() {
       <div className="sm:hidden pt-2">
         <Button asChild variant="outline" className="w-full border-primary/50 text-primary hover:bg-primary/10 group font-bold">
             <Link href="/library">
-                View Library <ArrowRight className="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1" />
+                <span>Library</span> <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
             </Link>
         </Button>
       </div>

--- a/src/components/recommendations-shelf.tsx
+++ b/src/components/recommendations-shelf.tsx
@@ -36,7 +36,7 @@ export function RecommendationsShelf() {
         {items.map((item) => (
             <div 
               key={item.id} 
-              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-all cursor-pointer border border-border snap-start"
+              className="group relative flex-none w-[calc(50%-0.5rem)] md:w-[calc(25%-0.75rem)] lg:w-[calc(14.285%-0.857rem)] aspect-[2/3] bg-muted rounded-lg overflow-hidden shadow-sm hover:scale-[1.03] transition-[transform,box-shadow] duration-200 cursor-pointer border border-border snap-start"
               onClick={() => router.push(`/library/series?path=${encodeURIComponent(item.path)}`)}
             >
               {item.coverUrl ? (
@@ -48,7 +48,7 @@ export function RecommendationsShelf() {
               )}
 
               {/* Default Bottom Gradient (Fades out on hover) */}
-              <div className="absolute bottom-0 left-0 w-full p-3 bg-gradient-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-300 pointer-events-none">
+              <div className="absolute bottom-0 left-0 w-full p-3 bg-linear-to-t from-black/90 via-black/60 to-transparent z-10 group-hover:opacity-0 transition-opacity duration-200 ease-out pointer-events-none">
                   <div className="flex flex-col mb-1.5">
                       <p className="text-white font-bold text-xs truncate drop-shadow-md">{item.name}</p>
                       {item.issueCount !== undefined && (
@@ -60,7 +60,7 @@ export function RecommendationsShelf() {
               </div>
 
               {/* Hover Overlay matching Recently Added */}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
+              <div className="absolute inset-0 bg-linear-to-t from-black/95 via-black/60 to-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-200 ease-out hidden sm:flex flex-col justify-end p-4 text-center gap-2 z-20">
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   

--- a/src/components/recommendations-shelf.tsx
+++ b/src/components/recommendations-shelf.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Sparkles, Image as ImageIcon, Library } from "lucide-react"; 
+import { Sparkles, Image as ImageIcon, Library, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function RecommendationsShelf() {
@@ -64,15 +64,15 @@ export function RecommendationsShelf() {
                   <h3 className="text-white font-bold text-sm line-clamp-2 drop-shadow-md">{item.name}</h3>
                   <p className="text-white/80 text-xs mb-2 drop-shadow-md">{item.year || '????'}</p>
                   
-                  <Button 
-                      size="sm" 
-                      className="w-full font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0" 
+                  <Button
+                      size="sm"
+                      className="w-full min-w-0 font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-md border-0"
                       onClick={(e) => {
                           e.stopPropagation();
                           router.push(`/library/series?path=${encodeURIComponent(item.path)}`);
                       }}
                   >
-                      <Library className="w-3 h-3 mr-2" /> View Series
+                      <Eye className="w-3 h-3 shrink-0" /> <span>View</span>
                   </Button>
               </div>
             </div>

--- a/src/components/request-search.tsx
+++ b/src/components/request-search.tsx
@@ -14,6 +14,7 @@ import { useLibraryOwnership } from "@/hooks/use-library-ownership"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import Link from "next/link"
 import { InteractiveSearchModal } from "./interactive-search-modal"
+import { cn } from "@/lib/utils"
 
 interface SearchResult {
   id: number;
@@ -325,9 +326,9 @@ export function RequestSearch() {
                       
                       <div className="relative aspect-[2/3] w-full rounded-lg overflow-hidden border bg-muted shadow-md border-border transition-colors duration-300">
                         {item.image ? (
-                            <img src={item.image} alt={item.name} className="absolute inset-0 w-full h-full object-contain transition-transform duration-300 group-hover:scale-105" />
+                            <img src={item.image} alt={item.name} className="absolute inset-0 w-full h-full object-contain transition-transform duration-200 ease-out group-hover:scale-105" />
                         ) : (
-                            <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30 transition-transform duration-300 group-hover:scale-105">
+                            <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30">
                                 <ImageIcon className="w-10 h-10 mb-2" />
                             </div>
                         )}
@@ -337,7 +338,7 @@ export function RequestSearch() {
                         {volStatus === 'REQUESTED' && (<div className="absolute top-2 right-2 bg-orange-500 text-white rounded-full p-1 z-10 shadow-md" title="Requested"><Clock className="w-4 h-4" /></div>)}
                         {volStatus === 'PENDING_APPROVAL' && (<div className="absolute top-2 right-2 bg-yellow-500 text-white rounded-full p-1 z-10 shadow-md" title="Pending Admin Approval"><Clock className="w-4 h-4" /></div>)}
                         
-                        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center z-20">
+                        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center z-20">
                           <Button size="sm" className="font-bold shadow-md">Details</Button>
                         </div>
                       </div>
@@ -380,11 +381,11 @@ export function RequestSearch() {
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-[280px_1fr] gap-8 mb-8">
                       <div className="space-y-5 flex flex-col items-center md:items-stretch">
-                          <div className="relative aspect-[2/3] w-[200px] md:w-[240px] mx-auto rounded-lg overflow-hidden border bg-muted shadow-md border-border transition-colors duration-300">
+                          <div className="relative aspect-[2/3] w-[200px] md:w-60 mx-auto rounded-lg overflow-hidden border bg-muted shadow-md border-border transition-colors duration-300">
                               {selectedItem.image ? (
                                   <img src={selectedItem.image} alt={selectedItem.name} className="absolute inset-0 w-full h-full object-contain" />
                               ) : (
-                                  <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30 transition-transform duration-300">
+                                  <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-muted text-muted-foreground/30">
                                       <ImageIcon className="w-12 h-12 mb-2" />
                                   </div>
                               )}
@@ -411,21 +412,21 @@ export function RequestSearch() {
                                 <div className="flex flex-col gap-2.5 sm:gap-3 w-full max-w-[300px] mx-auto md:max-w-none mt-2">
                                     {/* VOLUME BUTTONS */}
                                     {loading ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal" variant="outline" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal" variant="outline" disabled>
                                             <Loader2 className="w-4 h-4 animate-spin shrink-0" /> <span className="leading-tight">Checking Library...</span>
                                         </Button>
                                     ) : volStatus === 'PENDING_APPROVAL' || volStatus === 'REQUESTED' ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal" variant="default" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal" variant="default" disabled>
                                             {volStatus === 'PENDING_APPROVAL' && <><Clock className="w-4 h-4 text-yellow-500 shrink-0" /> <span className="leading-tight">Pending Approval</span></>}
                                             {volStatus === 'REQUESTED' && <><Clock className="w-4 h-4 text-orange-500 shrink-0" /> <span className="leading-tight">Requested</span></>}
                                         </Button>
                                     ) : (isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') ? (
-                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" variant="outline" disabled>
+                                        <Button className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" variant="outline" disabled>
                                             <FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">Up to Date</span>
                                         </Button>
                                     ) : (isAllAvailableOwned && volStatus === 'LIBRARY_UNMONITORED') ? (
                                         <Button 
-                                            className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold bg-blue-600 hover:bg-blue-700 text-white whitespace-normal" 
+                                            className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold bg-blue-600 hover:bg-blue-700 text-white whitespace-normal" 
                                             variant="default" 
                                             onClick={() => handleRequest(selectedItem.volumeId, seriesBaseName, selectedItem.image, selectedItem.year, 'volume', selectedItem.publisher || 'Unknown', true, undefined, true, selectedItem.metadataSource || 'COMICVINE')} 
                                             disabled={requestingTarget === `vol-${selectedItem.volumeId}`}
@@ -436,7 +437,7 @@ export function RequestSearch() {
                                         </Button>
                                     ) : (
                                         <Button 
-                                            className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold whitespace-normal ${isVolOwned ? 'bg-green-600 hover:bg-green-700 text-white' : ''}`} 
+                                            className={cn("w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold whitespace-normal", isVolOwned && "bg-green-600 hover:bg-green-700 text-white")} 
                                             variant="default" 
                                             onClick={() => setMonitorPrompt({ id: selectedItem.volumeId, name: seriesBaseName, image: selectedItem.image, year: selectedItem.year, publisher: selectedItem.publisher || 'Unknown', metadataSource: selectedItem.metadataSource || 'COMICVINE' })} 
                                             disabled={requestingTarget === `vol-${selectedItem.volumeId}`}
@@ -449,11 +450,11 @@ export function RequestSearch() {
                                     
                                     {/* ISSUE BUTTONS */}
                                     {(isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') ? (
-                                        <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
+                                        <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
                                             <FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">Up to Date</span>
                                         </Button>
                                     ) : issueStatus === 'PENDING_APPROVAL' || issueStatus === 'REQUESTED' || issueStatus === 'UNRELEASED' || isIssueOwned ? (
-                                        <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
+                                        <Button className={`w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal`} variant="outline" disabled>
                                             {isIssueOwned && <><FileCheck className="w-4 h-4 text-emerald-500 shrink-0" /> <span className="leading-tight">In Library</span></>}
                                             {issueStatus === 'PENDING_APPROVAL' && <><Clock className="w-4 h-4 text-yellow-500 shrink-0" /> <span className="leading-tight">Pending Approval</span></>}
                                             {issueStatus === 'REQUESTED' && <><Clock className="w-4 h-4 text-orange-500 shrink-0" /> <span className="leading-tight">Requested</span></>}
@@ -461,7 +462,7 @@ export function RequestSearch() {
                                         </Button>
                                     ) : (
                                         <Button 
-                                            className="w-full gap-1.5 shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 whitespace-normal" 
+                                            className="w-full gap-1.5 shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 whitespace-normal" 
                                             variant="outline" 
                                             onClick={() => handleRequest(selectedItem.volumeId, selectedItem.isVolume ? seriesBaseName : selectedItem.name, selectedItem.image, selectedItem.year, 'issue', selectedItem.publisher, false, selectedItem.issueNumber, false, selectedItem.metadataSource || 'COMICVINE')} 
                                             disabled={requestingTarget === `iss-${issueTargetName}`}
@@ -472,7 +473,7 @@ export function RequestSearch() {
                                     
                                     <Button 
                                       variant="outline" 
-                                      className="w-full gap-1.5 border-dashed shadow-sm h-auto min-h-[2.5rem] py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" 
+                                      className="w-full gap-1.5 border-dashed shadow-sm h-auto min-h-10 py-1.5 text-sm font-bold border-border hover:bg-muted text-foreground whitespace-normal" 
                                       onClick={() => setInteractiveQuery({ query: selectedItem.isVolume ? seriesBaseName : selectedItem.name, type: selectedItem.isVolume ? 'issue' : 'volume' })}
                                       disabled={(isAllAvailableOwned && volStatus === 'LIBRARY_MONITORED') || (!selectedItem.isVolume && isIssueOwned) || overallStatus === 'PENDING_APPROVAL' || overallStatus === 'REQUESTED'}
                                     >
@@ -604,7 +605,7 @@ export function RequestSearch() {
                                                           <ImageIcon className="w-6 h-6" />
                                                       </div>
                                                   )}
-                                                  <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none" />
+                                                  <div className="absolute inset-0 bg-linear-to-t from-black/80 via-transparent to-transparent z-10 pointer-events-none" />
                                                   
                                                   <div className="absolute top-1 right-1 bg-black/80 text-white rounded-md px-1.5 py-0.5 text-[10px] font-bold z-20 shadow-sm border border-white/20">#{issue.issueNumber}</div>
 

--- a/src/components/request-search.tsx
+++ b/src/components/request-search.tsx
@@ -338,7 +338,7 @@ export function RequestSearch() {
                         {volStatus === 'PENDING_APPROVAL' && (<div className="absolute top-2 right-2 bg-yellow-500 text-white rounded-full p-1 z-10 shadow-md" title="Pending Admin Approval"><Clock className="w-4 h-4" /></div>)}
                         
                         <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center z-20">
-                          <Button size="sm" className="font-bold shadow-lg bg-primary hover:bg-primary/90 text-primary-foreground">Details</Button>
+                          <Button size="sm" className="font-bold shadow-md">Details</Button>
                         </div>
                       </div>
                       

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
+import { usePathname } from "next/navigation"
 import { useSession, signOut } from "next-auth/react"
 import { useTheme } from "next-themes"
 import { Button } from "@/components/ui/button"
@@ -73,8 +74,8 @@ function NotificationBell() {
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative h-10 w-10 sm:h-9 sm:w-9 group hover:bg-primary/10 transition-colors">
-          <Bell className="h-6 w-6 sm:h-5 sm:w-5 text-muted-foreground group-hover:text-primary transition-colors" />
+        <Button variant="ghost" size="icon" className="relative h-10 w-10 group hover:bg-primary/10 transition-colors">
+          <Bell className="h-5 w-5 text-muted-foreground group-hover:text-primary transition-colors" />
           {notifications.length > 0 && (
             <span className="absolute top-1.5 right-1.5 flex h-2.5 w-2.5">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
@@ -190,6 +191,7 @@ export function SiteHeader() {
   const { data: session, status } = useSession()
   const { theme, setTheme, resolvedTheme } = useTheme()
   const { toast } = useToast()
+  const pathname = usePathname()
   
   const [mounted, setMounted] = useState(false)
   useEffect(() => { setMounted(true) }, [])
@@ -256,14 +258,14 @@ export function SiteHeader() {
       className="sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 shadow-sm transition-colors duration-300"
     >
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6">
-        
-        <div className="flex gap-2 sm:gap-6 items-center">
-          
-          {/* MOBILE HAMBURGER MENU */}
+
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0">
+
+          {/* MOBILE HAMBURGER MENU — shows below lg */}
           {!mounted ? (
-             <div className="md:hidden w-10 h-10 shrink-0" />
+             <div className="lg:hidden w-10 h-10 shrink-0" />
           ) : session ? (
-            <div className="md:hidden flex items-center">
+            <div className="lg:hidden flex items-center shrink-0">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="ghost" size="icon" className="h-10 w-10 shrink-0">
@@ -271,19 +273,19 @@ export function SiteHeader() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-64 mt-2 p-2 bg-popover border-border shadow-xl rounded-xl z-50">
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname === "/" ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/">Home</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/library") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/library">Library</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/reading-lists") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/reading-lists">Reading Lists</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/requests") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/requests">My Requests</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className="p-3 text-base font-medium cursor-pointer rounded-lg hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/calendar") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
                     <Link href="/calendar">Release Calendar</Link>
                   </DropdownMenuItem>
                   {session?.user?.role === "ADMIN" && (
@@ -299,32 +301,26 @@ export function SiteHeader() {
             </div>
           ) : null}
 
-          <Link href="/" className="flex items-center transition-transform hover:scale-[1.02] text-foreground">
-            <OmnibusLogo className="w-36 sm:w-56 h-auto shrink-0" />
+          <Link href="/" className="flex items-center transition-transform hover:scale-[1.02] text-foreground shrink-0">
+            <OmnibusLogo className="w-28 sm:w-44 lg:w-56 h-auto" />
           </Link>
-          
-          {/* DESKTOP NAV */}
-          <nav className="hidden md:flex gap-6 ml-4 items-center">
-            <Link href="/" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Home</Link>
-            <Link href="/library" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Library</Link>
-            <Link href="/reading-lists" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Reading Lists</Link>
-            <Link href="/requests" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">My Requests</Link>
-            <Link href="/calendar" className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors">Release Calendar</Link>
-            
-            {session?.user?.role === "ADMIN" && (
-                <Button variant="outline" size="sm" className="h-8 gap-1.5 border-primary/20 bg-primary/10 text-primary hover:bg-primary/20 hover:text-primary transition-colors" asChild>
-                  <Link href="/admin"><ShieldAlert className="w-3.5 h-3.5" /> Admin</Link>
-                </Button>
-            )}
+
+          {/* DESKTOP NAV — TORN PAPER RIBBON (lg+) */}
+          <nav className="ribbon-nav hidden lg:flex items-center">
+            <Link href="/" className={`ribbon-link ribbon-red ${pathname === "/" ? "active" : ""}`}>Home</Link>
+            <Link href="/library" className={`ribbon-link ribbon-blue ${pathname?.startsWith("/library") ? "active" : ""}`}>Library</Link>
+            <Link href="/reading-lists" className={`ribbon-link ribbon-green ${pathname?.startsWith("/reading-lists") ? "active" : ""}`}>Reading Lists</Link>
+            <Link href="/requests" className={`ribbon-link ribbon-purple ${pathname?.startsWith("/requests") ? "active" : ""}`}>My Requests</Link>
+            <Link href="/calendar" className={`ribbon-link ribbon-yellow ${pathname?.startsWith("/calendar") ? "active" : ""}`}>Calendar</Link>
           </nav>
         </div>
 
         {/* RIGHT SIDE ICONS */}
-        <div className="flex items-center gap-1 sm:gap-4">
+        <div className="flex items-center gap-2 sm:gap-3 shrink-0">
           {!mounted ? (
-            <div className="flex items-center gap-2 sm:gap-4">
+            <div className="flex items-center gap-2 sm:gap-3">
               <div className="hidden sm:block w-14 h-7 rounded-full bg-muted animate-pulse" />
-              <div className="w-10 h-10 rounded-full bg-muted animate-pulse ml-1" />
+              <div className="w-10 h-10 rounded-full bg-muted animate-pulse" />
             </div>
           ) : (
             <>
@@ -359,11 +355,11 @@ export function SiteHeader() {
               </button>
 
               {status === "loading" ? (
-                 <div className="w-10 h-10 bg-muted animate-pulse rounded-full ml-1" />
+                 <div className="w-10 h-10 bg-muted animate-pulse rounded-full" />
               ) : session ? (
                  <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                        <Button variant="outline" className="relative h-10 w-10 sm:h-10 sm:w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 ml-1 transition-colors">
+                        <Button variant="outline" className="relative h-10 w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 transition-colors">
                             {session.user?.image ? (
                               <img 
                                 src={session.user.image.startsWith('/') || session.user.image.startsWith('http') ? session.user.image : `/${session.user.image}`} 
@@ -371,38 +367,43 @@ export function SiteHeader() {
                                 className="w-full h-full object-cover" 
                               />
                               ) : (
-                                <UserIcon className="w-5 h-5 sm:w-5 sm:h-5 text-foreground" />
+                                <UserIcon className="w-5 h-5 text-foreground" />
                             )}
                         </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-64 sm:w-56 mt-2 sm:mt-0 p-2 sm:p-1 bg-popover border-border rounded-xl sm:rounded-md shadow-xl">
-                        <DropdownMenuLabel className="font-normal p-3 sm:p-2">
+                    <DropdownMenuContent align="end" className="w-56 p-1 bg-popover border-border rounded-md shadow-xl">
+                        <DropdownMenuLabel className="font-normal p-2">
                             <div className="flex flex-col space-y-1.5">
-                                <p className="text-base sm:text-sm font-bold leading-none">{session.user?.name}</p>
+                                <p className="text-sm font-bold leading-none">{session.user?.name}</p>
                                 <div className="flex items-center gap-2">
-                                    <p className="text-xs sm:text-[10px] uppercase font-bold tracking-wider text-muted-foreground">{session.user?.role}</p>
+                                    <p className="text-[10px] uppercase font-bold tracking-wider text-muted-foreground">{session.user?.role}</p>
                                     {session.user && <TierBadge user={session.user as any} />}
                                 </div>
                             </div>
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator className="bg-border" />
                         
-                        <div className="sm:hidden p-3 flex items-center justify-between">
+                        <div className="lg:hidden p-2 flex items-center justify-between">
                           <span className="text-sm font-medium">Dark Mode</span>
                           <Switch checked={isDark} onCheckedChange={(c) => setTheme(c ? "dark" : "light")} />
                         </div>
-                        <DropdownMenuSeparator className="bg-border sm:hidden" />
+                        <DropdownMenuSeparator className="bg-border lg:hidden" />
 
-                        <DropdownMenuItem asChild className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
-                            <Link href="/profile"><UserIcon className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Profile</Link>
+                        <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
+                            <Link href="/profile"><UserIcon className="w-4 h-4 mr-2" /> Profile</Link>
                         </DropdownMenuItem>
-                        <DropdownMenuItem className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors" onClick={() => setPassModalOpen(true)}>
-                            <Key className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Change Password
+                        <DropdownMenuItem className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors" onClick={() => setPassModalOpen(true)}>
+                            <Key className="w-4 h-4 mr-2" /> Change Password
                         </DropdownMenuItem>
+                        {session?.user?.role === "ADMIN" && (
+                          <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm text-primary hover:bg-primary/10 focus:bg-primary/20 focus:text-primary transition-colors">
+                            <Link href="/admin"><ShieldAlert className="w-4 h-4 mr-2" /> Admin Dashboard</Link>
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator className="bg-border my-1" />
-                        
-                        <DropdownMenuItem 
-                          className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors" 
+
+                        <DropdownMenuItem
+                          className="p-2 text-sm cursor-pointer rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors"
                           onClick={(e) => {
                             e.preventDefault();
                             signOut({ redirect: false }).then(() => {
@@ -410,7 +411,7 @@ export function SiteHeader() {
                             });
                           }}
                         >
-                            <LogOut className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Log Out
+                            <LogOut className="w-4 h-4 mr-2" /> Log Out
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                  </DropdownMenu>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -21,6 +21,7 @@ import { OmnibusLogo } from "@/components/omnibus-logo"
 import { Badge } from "@/components/ui/badge"
 import { Switch } from "@/components/ui/switch"
 import { TierBadge } from "@/components/tier-badge"
+import { cn } from "@/lib/utils"
 
 // --- INTERNAL NOTIFICATION COMPONENT ---
 function NotificationBell() {
@@ -273,19 +274,19 @@ export function SiteHeader() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="w-64 mt-2 p-2 bg-popover border-border shadow-xl rounded-xl z-50">
-                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname === "/" ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
+                  <DropdownMenuItem asChild className={cn("p-3 text-base font-medium cursor-pointer rounded-lg transition-colors", pathname === "/" ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary")}>
                     <Link href="/">Home</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/library") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
+                  <DropdownMenuItem asChild className={cn("p-3 text-base font-medium cursor-pointer rounded-lg transition-colors", pathname?.startsWith("/library") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary")}>
                     <Link href="/library">Library</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/reading-lists") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
+                  <DropdownMenuItem asChild className={cn("p-3 text-base font-medium cursor-pointer rounded-lg transition-colors", pathname?.startsWith("/reading-lists") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary")}>
                     <Link href="/reading-lists">Reading Lists</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/requests") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
+                  <DropdownMenuItem asChild className={cn("p-3 text-base font-medium cursor-pointer rounded-lg transition-colors", pathname?.startsWith("/requests") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary")}>
                     <Link href="/requests">My Requests</Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild className={`p-3 text-base font-medium cursor-pointer rounded-lg transition-colors ${pathname?.startsWith("/calendar") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary"}`}>
+                  <DropdownMenuItem asChild className={cn("p-3 text-base font-medium cursor-pointer rounded-lg transition-colors", pathname?.startsWith("/calendar") ? "bg-primary/10 text-primary" : "hover:bg-muted focus:bg-primary/10 focus:text-primary")}>
                     <Link href="/calendar">Release Calendar</Link>
                   </DropdownMenuItem>
                   {session?.user?.role === "ADMIN" && (
@@ -302,16 +303,16 @@ export function SiteHeader() {
           ) : null}
 
           <Link href="/" className="flex items-center transition-transform hover:scale-[1.02] text-foreground shrink-0">
-            <OmnibusLogo className="w-28 sm:w-44 lg:w-56 h-auto" />
+            <OmnibusLogo className="w-28 sm:w-40 lg:w-48 h-auto" />
           </Link>
 
-          {/* DESKTOP NAV — TORN PAPER RIBBON (lg+) */}
-          <nav className="ribbon-nav hidden lg:flex items-center">
-            <Link href="/" className={`ribbon-link ribbon-red ${pathname === "/" ? "active" : ""}`}>Home</Link>
-            <Link href="/library" className={`ribbon-link ribbon-blue ${pathname?.startsWith("/library") ? "active" : ""}`}>Library</Link>
-            <Link href="/reading-lists" className={`ribbon-link ribbon-green ${pathname?.startsWith("/reading-lists") ? "active" : ""}`}>Reading Lists</Link>
-            <Link href="/requests" className={`ribbon-link ribbon-purple ${pathname?.startsWith("/requests") ? "active" : ""}`}>My Requests</Link>
-            <Link href="/calendar" className={`ribbon-link ribbon-yellow ${pathname?.startsWith("/calendar") ? "active" : ""}`}>Calendar</Link>
+          {/* DESKTOP NAV — COMIC PANEL FRAME (lg+) */}
+          <nav className="hidden lg:flex items-center gap-2">
+            <Link href="/" className={cn("uppercase tracking-[0.08em] font-extrabold text-sm px-3 py-1.5 whitespace-nowrap transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95", pathname === "/" ? "bg-card border-2 border-primary shadow-[3px_3px_0_rgb(0_0_0/0.45)] dark:shadow-[3px_3px_0_rgb(255_255_255/0.2)] text-primary transition-all" : "text-muted-foreground hover:text-foreground")}>Home</Link>
+            <Link href="/library" className={cn("uppercase tracking-[0.08em] font-extrabold text-sm px-3 py-1.5 whitespace-nowrap transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95", pathname?.startsWith("/library") ? "bg-card border-2 border-primary shadow-[3px_3px_0_rgb(0_0_0/0.45)] dark:shadow-[3px_3px_0_rgb(255_255_255/0.2)] text-primary transition-all" : "text-muted-foreground hover:text-foreground")}>Library</Link>
+            <Link href="/reading-lists" className={cn("uppercase tracking-[0.08em] font-extrabold text-sm px-3 py-1.5 whitespace-nowrap transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95", pathname?.startsWith("/reading-lists") ? "bg-card border-2 border-primary shadow-[3px_3px_0_rgb(0_0_0/0.45)] dark:shadow-[3px_3px_0_rgb(255_255_255/0.2)] text-primary transition-all" : "text-muted-foreground hover:text-foreground")}>Reading Lists</Link>
+            <Link href="/requests" className={cn("uppercase tracking-[0.08em] font-extrabold text-sm px-3 py-1.5 whitespace-nowrap transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95", pathname?.startsWith("/requests") ? "bg-card border-2 border-primary shadow-[3px_3px_0_rgb(0_0_0/0.45)] dark:shadow-[3px_3px_0_rgb(255_255_255/0.2)] text-primary transition-all" : "text-muted-foreground hover:text-foreground")}>My Requests</Link>
+            <Link href="/calendar" className={cn("uppercase tracking-[0.08em] font-extrabold text-sm px-3 py-1.5 whitespace-nowrap transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95", pathname?.startsWith("/calendar") ? "bg-card border-2 border-primary shadow-[3px_3px_0_rgb(0_0_0/0.45)] dark:shadow-[3px_3px_0_rgb(255_255_255/0.2)] text-primary transition-all" : "text-muted-foreground hover:text-foreground")}>Calendar</Link>
           </nav>
         </div>
 
@@ -319,7 +320,7 @@ export function SiteHeader() {
         <div className="flex items-center gap-2 sm:gap-3 shrink-0">
           {!mounted ? (
             <div className="flex items-center gap-2 sm:gap-3">
-              <div className="hidden sm:block w-14 h-7 rounded-full bg-muted animate-pulse" />
+              <div className="hidden lg:block w-14 h-7 rounded-full bg-muted animate-pulse" />
               <div className="w-10 h-10 rounded-full bg-muted animate-pulse" />
             </div>
           ) : (
@@ -340,17 +341,15 @@ export function SiteHeader() {
 
               <button
                 onClick={() => setTheme(isDark ? "light" : "dark")}
-                className={`relative flex items-center w-14 h-7 rounded-full p-1 cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 shadow-inner hidden sm:flex bg-muted border border-border hover:border-primary/50`}
+                className={`relative flex items-center w-14 h-7 rounded-full p-1 cursor-pointer transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 shadow-inner hidden lg:flex bg-muted border border-border hover:border-primary/50`}
                 aria-label="Toggle Dark Mode"
               >
                 <div 
-                  className={`absolute w-5 h-5 rounded-full shadow-md transition-transform duration-300 ease-in-out ${
-                    isDark ? "translate-x-7 bg-background" : "translate-x-0 bg-background"
-                  }`} 
+                  className={cn("absolute w-5 h-5 rounded-full shadow-md transition-transform duration-200 ease-out motion-reduce:transition-none", isDark ? "translate-x-7 bg-background" : "translate-x-0 bg-background")} 
                 />
                 <div className="relative z-10 flex justify-between w-full px-0.5 pointer-events-none">
-                  <Sun className={`w-3.5 h-3.5 transition-colors ${isDark ? "text-muted-foreground" : "text-primary"}`} />
-                  <Moon className={`w-3.5 h-3.5 transition-colors ${isDark ? "text-primary" : "text-muted-foreground"}`} />
+                  <Sun className={cn("w-3.5 h-3.5 transition-colors duration-200 ease-out", isDark ? "text-muted-foreground" : "text-primary")} />
+                  <Moon className={cn("w-3.5 h-3.5 transition-colors duration-200 ease-out", isDark ? "text-primary" : "text-muted-foreground")} />
                 </div>
               </button>
 
@@ -359,7 +358,7 @@ export function SiteHeader() {
               ) : session ? (
                  <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                        <Button variant="outline" className="relative h-10 w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 transition-colors">
+                        <Button variant="outline" className="relative h-10 w-10 rounded-full bg-muted border-2 border-border hover:border-primary/50 overflow-hidden p-0 transition-colors duration-200 ease-out motion-reduce:transition-none active:scale-95 active:border-primary">
                             {session.user?.image ? (
                               <img 
                                 src={session.user.image.startsWith('/') || session.user.image.startsWith('http') ? session.user.image : `/${session.user.image}`} 
@@ -371,8 +370,8 @@ export function SiteHeader() {
                             )}
                         </Button>
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-56 p-1 bg-popover border-border rounded-md shadow-xl">
-                        <DropdownMenuLabel className="font-normal p-2">
+                    <DropdownMenuContent align="end" className="w-64 sm:w-56 p-2 sm:p-1 bg-popover border-border rounded-xl sm:rounded-md shadow-xl">
+                        <DropdownMenuLabel className="font-normal p-3 sm:p-2">
                             <div className="flex flex-col space-y-1.5">
                                 <p className="text-sm font-bold leading-none">{session.user?.name}</p>
                                 <div className="flex items-center gap-2">
@@ -383,27 +382,27 @@ export function SiteHeader() {
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator className="bg-border" />
                         
-                        <div className="lg:hidden p-2 flex items-center justify-between">
-                          <span className="text-sm font-medium">Dark Mode</span>
+                        <div className="lg:hidden p-3 sm:p-2 flex items-center justify-between">
+                          <span className="text-base sm:text-sm font-medium">Dark Mode</span>
                           <Switch checked={isDark} onCheckedChange={(c) => setTheme(c ? "dark" : "light")} />
                         </div>
                         <DropdownMenuSeparator className="bg-border lg:hidden" />
 
-                        <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors">
-                            <Link href="/profile"><UserIcon className="w-4 h-4 mr-2" /> Profile</Link>
+                        <DropdownMenuItem asChild className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors duration-150 ease-out motion-reduce:transition-none active:scale-[0.98]">
+                            <Link href="/profile"><UserIcon className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Profile</Link>
                         </DropdownMenuItem>
-                        <DropdownMenuItem className="p-2 text-sm cursor-pointer rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors" onClick={() => setPassModalOpen(true)}>
-                            <Key className="w-4 h-4 mr-2" /> Change Password
+                        <DropdownMenuItem className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm hover:bg-muted focus:bg-primary/10 focus:text-primary transition-colors duration-150 ease-out motion-reduce:transition-none active:scale-[0.98]" onClick={() => setPassModalOpen(true)}>
+                            <Key className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Change Password
                         </DropdownMenuItem>
                         {session?.user?.role === "ADMIN" && (
-                          <DropdownMenuItem asChild className="p-2 text-sm cursor-pointer rounded-sm text-primary hover:bg-primary/10 focus:bg-primary/20 focus:text-primary transition-colors">
-                            <Link href="/admin"><ShieldAlert className="w-4 h-4 mr-2" /> Admin Dashboard</Link>
+                          <DropdownMenuItem asChild className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm text-primary hover:bg-primary/10 focus:bg-primary/20 focus:text-primary transition-colors duration-150 ease-out motion-reduce:transition-none active:scale-[0.98]">
+                            <Link href="/admin"><ShieldAlert className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Admin Dashboard</Link>
                           </DropdownMenuItem>
                         )}
                         <DropdownMenuSeparator className="bg-border my-1" />
 
                         <DropdownMenuItem
-                          className="p-2 text-sm cursor-pointer rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors"
+                          className="p-3 sm:p-2 text-base sm:text-sm cursor-pointer rounded-lg sm:rounded-sm text-red-600 focus:text-red-700 focus:bg-red-50 dark:text-red-400 dark:focus:bg-red-900/20 transition-colors duration-150 ease-out motion-reduce:transition-none active:scale-[0.98]"
                           onClick={(e) => {
                             e.preventDefault();
                             signOut({ redirect: false }).then(() => {
@@ -411,7 +410,7 @@ export function SiteHeader() {
                             });
                           }}
                         >
-                            <LogOut className="w-4 h-4 mr-2" /> Log Out
+                            <LogOut className="w-5 h-5 sm:w-4 sm:h-4 mr-3 sm:mr-2" /> Log Out
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                  </DropdownMenu>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex min-w-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex min-w-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex min-w-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-200 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- **Header redesign**: Comic/manga-inspired torn-paper ribbon navigation with color-coded ribbons per route (red/blue/green/purple/yellow) and active state highlighting via `usePathname`
- **Admin moved to avatar dropdown**: Removed Admin button from desktop nav, now lives in the user avatar menu (Profile > Change Password > Admin Dashboard > Log Out)
- **Responsive header**: Hamburger menu below `lg` (1024px), ribbon nav at `lg+`, logo scales across breakpoints (`w-28 sm:w-44 lg:w-56`), container width aligned with body pages
- **Button pattern cleanup**: Standardized card hover overlays to primary "Read" button full-width + secondary actions as icon-only buttons, applied consistently across library, series, calendar, and history pages
- **Bebas Neue font** added for ribbon labels

## Files changed (12)

**Header:**
- `src/components/site-header.tsx`
- `src/app/globals.css`

**Button pattern:**
- `src/components/ContinueReading.tsx`
- `src/components/comic-grid.tsx`
- `src/components/recently-added.tsx`
- `src/components/recommendations-shelf.tsx`
- `src/components/request-search.tsx`
- `src/components/ui/button.tsx`

**Responsive/button pattern applied to pages:**
- `src/app/calendar/page.tsx`
- `src/app/library/history/page.tsx`
- `src/app/library/page.tsx`
- `src/app/library/series/page.tsx`

<img width="1848" height="876" alt="screenshot-2026-07-17_01-23-41" src="https://github.com/user-attachments/assets/18552b78-bc04-491d-ba63-369ec3d557e2" />
<img width="636" height="577" alt="screenshot-2026-07-17_01-26-19" src="https://github.com/user-attachments/assets/1a2424ae-f833-4a19-a4a9-2750f5e25bed" />