### PR TITLE
feat(search): support localized comic packs and safe batch imports

### DIFF
--- a/__tests__/lib/importer.test.ts
+++ b/__tests__/lib/importer.test.ts
@@ -203,6 +203,26 @@ describe('File System: Importer Engine', () => {
         }));
     });
 
+    it('holds a flat collection for manual review instead of fabricating issue 1', async () => {
+        mocks.findUniqueRequest.mockResolvedValueOnce({
+            id: 'req_flat_pack', status: 'DOWNLOADING',
+            activeDownloadName: 'Thorgal.Collection.73 Albums.FR.CBZ'
+        });
+
+        const result = await Importer.importRequest('req_flat_pack');
+
+        expect(result).toBe(false);
+        expect(fs.copy).toHaveBeenCalledWith(
+            expect.stringContaining('Thorgal.Collection.73 Albums.FR.CBZ'),
+            expect.stringContaining('/unmatched/'),
+            expect.any(Object)
+        );
+        expect(mocks.updateRequest).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ status: 'STALLED' })
+        }));
+        expect(mocks.createIssue).not.toHaveBeenCalled();
+    });
+
     // ==== Issue #174: RAR packs (the dominant Usenet/scene container) must be batch-split too. ====
 
     it('routes a nested RAR batch pack to WATCHED via the engine (issue #174)', async () => {

--- a/__tests__/lib/search-engine.test.ts
+++ b/__tests__/lib/search-engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { generateSearchQueries } from '@/lib/search-engine';
+import { isPackTitle, parseIssueRange } from '@/lib/utils/issue-parser';
 
 describe('Core Logic: Fuzzy Search Generator', () => {
     const customAcronyms = {
@@ -47,5 +48,27 @@ describe('Core Logic: Fuzzy Search Generator', () => {
         // It should expand TMNT out fully
         expect(queries).toContain('teenage mutant ninja turtles 2020');
         expect(queries).toContain('teenage mutant ninja turtles');
+    });
+
+    it('generates localized French pack queries', () => {
+        const queries = generateSearchQueries('Thorgal #1', '2011', customAcronyms, false, true, true);
+        expect(queries).toContain('Thorgal integrale');
+        expect(queries).toContain('Thorgal albums');
+        expect(queries).toContain('Thorgal tomes');
+    });
+
+    it('prioritizes localized aliases for pack queries', () => {
+        const queries = generateSearchQueries('Elves 3', '2016', { elves: 'elfes' }, false, true, true);
+        expect(queries[0]).toBe('elfes');
+        expect(queries.indexOf('elfes collection')).toBeLessThan(queries.indexOf('Elves collection'));
+    });
+
+    it('recognizes French ranges without treating REPACK as a pack', () => {
+        expect(isPackTitle('Thorgal.le.cycle.de.Qa.2012.FRENCH.REPACK.CBZ')).toBe(false);
+        expect(isPackTitle('Thorgal.Collection.73 Albums.FR.CBZ')).toBe(true);
+        expect(isPackTitle('Thorgal T1 à T39 [CBZ]')).toBe(true);
+        expect(isPackTitle('Elfes.T1.T35.FR.[CBZ]')).toBe(true);
+        expect(parseIssueRange('Thorgal T1 à T39 [CBZ]')).toEqual({ start: 1, end: 39 });
+        expect(parseIssueRange('Elfes.T1.T35.FR.[CBZ]')).toEqual({ start: 1, end: 35 });
     });
 });

--- a/omnibus-engine/src/getcomics.rs
+++ b/omnibus-engine/src/getcomics.rs
@@ -319,18 +319,7 @@ pub(crate) fn interactive_query_variants(queries: &[String]) -> Vec<String> {
 /// is read as a release-date range, not an issue range, and the end must exceed the start. Kept in
 /// lock-step with issue-parser.ts parseIssueRange.
 pub fn parse_issue_range(title: &str) -> Option<(u32, u32)> {
-    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    let re = RE.get_or_init(|| {
-        regex::Regex::new(r"(?i)(?:#|issues?\s*#?|vol(?:ume)?\.?\s*|v\.?\s*)?(\d{1,4})\s*(?:[-–—]|\bto\b)\s*#?(\d{1,4})").unwrap()
-    });
-    for cap in re.captures_iter(title) {
-        let start = match cap.get(1).and_then(|m| m.as_str().parse::<u32>().ok()) { Some(v) => v, None => continue };
-        let end = match cap.get(2).and_then(|m| m.as_str().parse::<u32>().ok()) { Some(v) => v, None => continue };
-        let both_look_like_years = (1900..=2099).contains(&start) && (1900..=2099).contains(&end);
-        if both_look_like_years { continue; }
-        if end > start { return Some((start, end)); }
-    }
-    None
+    crate::search_engine::parse_issue_range(title)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -385,9 +374,9 @@ pub async fn search(
 
     let mut tpb_terms: Vec<&str> = vec!["omnibus", "tpb", "compendium", "collection", "hc", "hardcover", "trade paperback"];
     if !is_manga { tpb_terms.extend_from_slice(&["vol ", "volume ", "book "]); }
-    let pack_terms = ["story arc", "pack", "complete", "collection", "bundle", "run", "chronological"];
     let is_looking_for_omnibus = tpb_terms.iter().any(|t| clean_original.contains(t));
     let is_looking_for_annual = clean_original.contains("annual");
+    let search_aliases = crate::search_engine::get_custom_acronyms(db).await.unwrap_or_default();
 
     let original_query_words: Vec<String> = clean_original.chars()
         .map(|c| if c.is_alphanumeric() { c } else { ' ' })
@@ -479,6 +468,11 @@ pub async fn search(
 
             for (title, link, size) in posts_data {
                 let title_lower = title.to_lowercase();
+                let match_title_lower = crate::search_engine::canonicalize_title_aliases(
+                    &title_lower,
+                    &clean_original,
+                    &search_aliases,
+                );
                 let mut is_relevant = true;
 
                 // --- BASELINE FILTERS (both automated and interactive, beta.035) ---
@@ -500,7 +494,7 @@ pub async fn search(
                         }
                     }
                     for w in &words_to_enforce {
-                        if !w.chars().all(char::is_numeric) && !title_lower.contains(w) {
+                        if !w.chars().all(char::is_numeric) && !match_title_lower.contains(w) {
                             is_relevant = false;
                             break;
                         }
@@ -523,8 +517,7 @@ pub async fn search(
                     // A multi-issue/volume RANGE in the title ("#0 – 9", "Vol. 1 – 4") is the most reliable
                     // batch signal — GetComics bundles older runs as ranges with no pack KEYWORD. Treat those
                     // as packs too (when bulk is enabled) so volume-batches aren't rejected as unwanted TPBs.
-                    let is_pack = allow_bulk_packs
-                        && (pack_terms.iter().any(|t| title_lower.contains(t)) || parse_issue_range(&title_lower).is_some());
+                    let is_pack = allow_bulk_packs && crate::search_engine::is_pack_title(&title_lower);
 
                     // TPB guard: reject collected editions when a single issue was requested.
                     if req_num.is_some() && !is_looking_for_omnibus && !is_pack {
@@ -562,7 +555,7 @@ pub async fn search(
                     // exempt (they legitimately carry extra words); interactive search never reaches
                     // this block, so manual picks stay unrestricted.
                     if is_relevant && req_num.is_some() && !is_pack && !significant_query_words.is_empty() {
-                        let extra = crate::search_engine::off_series_extra_words(&title_lower, &significant_query_words);
+                        let extra = crate::search_engine::off_series_extra_words(&match_title_lower, &significant_query_words);
                         if !extra.is_empty() {
                             log::debug!("[GetComics Debug] Discarding off-series post \"{}\" — extra series words {:?} not in requested \"{}\".", title, extra, clean_original);
                             is_relevant = false;
@@ -1007,6 +1000,8 @@ mod tests {
         assert_eq!(parse_issue_range("Crossed #0 - 9"), Some((0, 9)));
         assert_eq!(parse_issue_range("Saga Vol. 1 – 4 (2019)"), Some((1, 4)));
         assert_eq!(parse_issue_range("Hellboy 1 to 12"), Some((1, 12)));
+        assert_eq!(parse_issue_range("Thorgal T1 à T39 [CBZ]"), Some((1, 39)));
+        assert_eq!(parse_issue_range("Elfes.T1.T35.FR.[CBZ]"), Some((1, 35)));
         // A both-ends-years span is a date range, not an issue range.
         assert_eq!(parse_issue_range("The Boys (2008-2010)"), None);
         // A single issue has no range.

--- a/omnibus-engine/src/search_engine.rs
+++ b/omnibus-engine/src/search_engine.rs
@@ -35,6 +35,58 @@ fn re_bounded_variant() -> &'static Regex {
     })
 }
 
+/// A multi-issue release marker must be a real token, not an arbitrary substring. In particular,
+/// scene tags such as `REPACK` are quality/version labels and must never bypass the issue-number
+/// guard merely because they contain the letters "pack".
+pub(crate) fn is_pack_title(title: &str) -> bool {
+    static RE_MARKER: OnceLock<Regex> = OnceLock::new();
+    static RE_COUNTED_FR: OnceLock<Regex> = OnceLock::new();
+    let marker = RE_MARKER.get_or_init(|| {
+        Regex::new(
+            r"(?ix)
+            (?:^|[^\p{L}\p{N}])
+            (?:
+                pack|story[\s._-]*arc|complete|complet(?:e|es)?|collection|bundle|run|
+                chronological|integrale|intégrale|mega[\s._-]*pack|méga[\s._-]*pack|
+                giga[\s._-]*pack
+            )
+            (?:$|[^\p{L}\p{N}])"
+        ).unwrap()
+    });
+    let counted_fr = RE_COUNTED_FR.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[^\p{L}\p{N}])\d+\s*(?:albums|tomes|hors[\s._-]*s[ée]rie(?:s)?|h\.?s\.?)\b").unwrap()
+    });
+
+    marker.is_match(title) || counted_fr.is_match(title) || parse_issue_range(title).is_some()
+}
+
+/// Detects a multi-issue / multi-volume range in both common scene syntax and French BD naming.
+/// Examples: `#1-39`, `Vol. 1 to 39`, `T1 à T39`, `T1.T35`, `tomes 1 au 39`.
+pub fn parse_issue_range(title: &str) -> Option<(u32, u32)> {
+    static RE_RANGE: OnceLock<Regex> = OnceLock::new();
+    static RE_COMPACT_T: OnceLock<Regex> = OnceLock::new();
+    let range = RE_RANGE.get_or_init(|| {
+        Regex::new(
+            r"(?ix)(?:\#|issues?\s*\#?|vol(?:ume)?\.?\s*|v\.?\s*|t(?:ome)?s?\.?\s*|albums?\.?\s*)?
+              (\d{1,4})\s*(?:[-–—]|\bto\b|\bau\b|à)\s*
+              (?:\#|vol(?:ume)?\.?\s*|v\.?\s*|t(?:ome)?\.?\s*)?(\d{1,4})"
+        ).unwrap()
+    });
+    let compact_t = RE_COMPACT_T.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[^\p{L}\p{N}])t(?:ome)?\.?\s*(\d{1,4})[\s._-]+t(?:ome)?\.?\s*(\d{1,4})(?:$|[^\p{L}\p{N}])").unwrap()
+    });
+
+    for re in [range, compact_t] {
+        for cap in re.captures_iter(title) {
+            let start = match cap.get(1).and_then(|m| m.as_str().parse::<u32>().ok()) { Some(v) => v, None => continue };
+            let end = match cap.get(2).and_then(|m| m.as_str().parse::<u32>().ok()) { Some(v) => v, None => continue };
+            let both_look_like_years = (1900..=2099).contains(&start) && (1900..=2099).contains(&end);
+            if !both_look_like_years && end > start { return Some((start, end)); }
+        }
+    }
+    None
+}
+
 /// Normalizes a release title to a comparable "edition" key (parity with automation.ts normalizeTitle).
 /// Used to detect when GetComics returns multiple distinct editions for one request.
 pub fn normalize_edition_title(t: &str) -> String {
@@ -104,6 +156,31 @@ pub async fn get_custom_acronyms(db: &sqlx::AnyPool) -> anyhow::Result<HashMap<S
         if !key.is_empty() && !val.is_empty() { ac_map.insert(key.to_lowercase(), val.to_lowercase()); }
     }
     Ok(ac_map)
+}
+
+/// Treat configured acronym expansions as search aliases during relevance validation too. Query
+/// generation already expands `elves -> elfes`; without canonicalizing the returned title, the
+/// strict filter immediately rejects the French result for not containing the ComicVine word
+/// `elves`. Only aliases present in the current request are applied, so unrelated mappings cannot
+/// loosen another series' match.
+pub(crate) fn canonicalize_title_aliases(
+    title: &str,
+    request: &str,
+    aliases: &HashMap<String, String>,
+) -> String {
+    let mut canonical = title.to_lowercase();
+    let request_lower = request.to_lowercase();
+    for (key, value) in aliases {
+        if key.trim().is_empty() || value.trim().is_empty() { continue; }
+        let key_re = Regex::new(&format!(r"(?i)\b{}\b", regex::escape(key))).ok();
+        let value_re = Regex::new(&format!(r"(?i)\b{}\b", regex::escape(value))).ok();
+        if key_re.as_ref().is_some_and(|re| re.is_match(&request_lower)) {
+            if let Some(re) = value_re { canonical = re.replace_all(&canonical, key.as_str()).to_string(); }
+        } else if value_re.as_ref().is_some_and(|re| re.is_match(&request_lower)) {
+            if let Some(re) = key_re { canonical = re.replace_all(&canonical, value.as_str()).to_string(); }
+        }
+    }
+    canonical
 }
 
 /// Insertion-ordered de-dup push (replaces the old HashSet so query order is deterministic —
@@ -229,7 +306,7 @@ pub fn generate_search_queries(
     }
     if expanded.to_lowercase() != broad_clean.to_lowercase() {
         if !year.is_empty() { add_query(&mut secondary, &mut secondary_seen, format!("{} {}", expanded, year)); }
-        add_query(&mut secondary, &mut secondary_seen, expanded);
+        add_query(&mut secondary, &mut secondary_seen, expanded.clone());
     }
 
     // --- PACK GENERATOR (beta.035): a separate gated group, optionally ordered first. ---
@@ -238,14 +315,27 @@ pub fn generate_search_queries(
     if use_packs {
         let re_series_only = Regex::new(r"(?i)\s\d+(?:\.\d+)?$").unwrap();
         let series_only_name = re_series_only.replace(&broad_clean, "").trim().to_string();
-        if series_only_name.len() > 2 {
-            if series_only_name != broad_clean {
-                add_query(&mut packs, &mut packs_seen, series_only_name.clone());
+        let expanded_series_only = re_series_only.replace(&expanded, "").trim().to_string();
+        let mut add_pack_queries = |series_name: &str, stripped_issue: bool| {
+            if series_name.len() > 2 {
+                if stripped_issue {
+                    add_query(&mut packs, &mut packs_seen, series_name.to_string());
+                }
+                add_query(&mut packs, &mut packs_seen, format!("{} collection", series_name));
+                add_query(&mut packs, &mut packs_seen, format!("{} story arc", series_name));
+                add_query(&mut packs, &mut packs_seen, format!("{} pack", series_name));
+                add_query(&mut packs, &mut packs_seen, format!("{} integrale", series_name));
+                add_query(&mut packs, &mut packs_seen, format!("{} albums", series_name));
+                add_query(&mut packs, &mut packs_seen, format!("{} tomes", series_name));
             }
-            add_query(&mut packs, &mut packs_seen, format!("{} collection", series_only_name));
-            add_query(&mut packs, &mut packs_seen, format!("{} story arc", series_only_name));
-            add_query(&mut packs, &mut packs_seen, format!("{} pack", series_only_name));
+        };
+
+        // Prefer the configured localized alias for packs. With slow indexers, every preceding
+        // query is expensive (for example ComicVine "Elves" versus French releases "Elfes").
+        if expanded_series_only.to_lowercase() != series_only_name.to_lowercase() {
+            add_pack_queries(&expanded_series_only, expanded_series_only != expanded);
         }
+        add_pack_queries(&series_only_name, series_only_name != broad_clean);
     }
 
     // The bare main-title queries (e.g. "X Men" / "X Men 2026" from a colon-split "X-Men: Outback #1")
@@ -387,7 +477,12 @@ fn reverse_noise_set() -> &'static std::collections::HashSet<String> {
         let mut s: std::collections::HashSet<String> =
             ["the", "a", "an", "of", "and", "or", "vol", "volume", "issue", "black", "white", "blood"]
                 .iter().map(|w| w.to_string()).collect();
-        for w in ["eng", "cbz", "cbr", "cb7", "zip", "rar", "webrip", "digital", "vol", "volume", "ch", "chapter", "issue", "tpb", "rip", "the", "and", "of", "by", "gn"] { s.insert(w.to_string()); }
+        for w in [
+            "eng", "english", "fr", "fre", "french", "vf", "cbz", "cbr", "cb7", "zip", "rar", "pdf",
+            "epub", "webrip", "digital", "hybrid", "comic", "ebook", "vol", "volume", "ch", "chapter",
+            "issue", "tpb", "rip", "the", "and", "of", "by", "gn", "notag", "toner", "printer", "team",
+            "remasterisee", "remasterise", "repack",
+        ] { s.insert(w.to_string()); }
         for w in &BOUNDED_VARIANT_KEYWORDS { s.insert(w.to_string()); }
         for k in &OPEN_VARIANT_KEYWORDS { for w in k.split_whitespace() { s.insert(w.to_string()); } }
         for w in ["cover", "covers", "scan", "scans", "noads", "c2c", "empire", "mobile", "edition"] { s.insert(w.to_string()); }
@@ -451,7 +546,7 @@ pub async fn filter_and_score(
     target_query: &str,
     is_manga: bool,
     req_year: Option<String>,
-    series_year: Option<String>,
+    _series_year: Option<String>,
     skip_relevance: bool,
     allow_packs_override: Option<bool>,
 ) -> anyhow::Result<Option<ProwlarrResult>> {
@@ -467,6 +562,9 @@ pub async fn filter_and_score(
     if allow_packs_override == Some(false) {
         allow_bulk_packs = false;
     }
+    let prioritize_packs = allow_bulk_packs && sqlx::query_scalar::<_, String>(r#"SELECT value FROM "SystemSetting" WHERE key = 'prioritize_packs'"#)
+        .fetch_optional(db).await?.unwrap_or_default() == "true";
+    let search_aliases = get_custom_acronyms(db).await.unwrap_or_default();
     let scoring_rules_str = sqlx::query_scalar::<_, String>(r#"SELECT value FROM "SystemSetting" WHERE key = 'release_scoring_rules'"#)
         .fetch_optional(db).await?.unwrap_or_default();
     let match_ratio_str = sqlx::query_scalar::<_, String>(r#"SELECT value FROM "SystemSetting" WHERE key = 'filter_match_ratio'"#)
@@ -513,7 +611,6 @@ pub async fn filter_and_score(
     let mut tpb_terms = vec!["omnibus", "tpb", "compendium", "collection", "hc", "hardcover", "trade paperback"];
     if !is_manga { tpb_terms.extend_from_slice(&["vol ", "volume ", "book "]); }
     let is_looking_for_omnibus = tpb_terms.iter().any(|term| clean_original.contains(term));
-    let pack_terms = ["story arc", "pack", "complete", "collection", "bundle", "run", "chronological"];
     let is_looking_for_annual = clean_original.contains("annual");
 
     let original_query_words: Vec<String> = clean_original.chars().map(|c| if c.is_alphanumeric() { c } else { ' ' })
@@ -529,13 +626,14 @@ pub async fn filter_and_score(
 
     // The reverse-guard noise set now lives in reverse_noise_set() (shared with the GetComics filter).
 
-    // Evaluate each result: None = rejected; Some(year_unconfirmed) = kept, where `true` marks an
-    // undated release admitted only via the opt-in `prowlarr_accept_yearless` (issue #176 change B).
+    // Evaluate each result: None = rejected; Some((year_unconfirmed, is_pack)) = kept.
     // Unconfirmed survivors sort BELOW every dated candidate regardless of score, so an undated release
     // only ever auto-downloads when nothing dated exists.
-    let evaluate = |res: &ProwlarrResult| -> Option<bool> {
+    let evaluate = |res: &ProwlarrResult| -> Option<(bool, bool)> {
         let title_lower = res.title.to_lowercase();
+        let match_title_lower = canonicalize_title_aliases(&title_lower, &clean_original, &search_aliases);
         let is_ddl = res.protocol == "ddl";
+        let is_pack = allow_bulk_packs && is_pack_title(&title_lower);
 
         for junk in &junk_words { if title_lower.contains(junk) { return None; } }
         for group in &exclude_groups { if title_lower.contains(group) { return None; } }
@@ -544,9 +642,7 @@ pub async fn filter_and_score(
         // Pre-filtered sources (GetComics, already validated per-query in getcomics::search) only get
         // the operator's junk/exclude lists + scoring — not this relevance filter, which is keyed on the
         // merged target_query rather than the specific query that produced the result.
-        if skip_relevance { return Some(false); }
-
-        let is_pack = allow_bulk_packs && pack_terms.iter().any(|term| title_lower.contains(term));
+        if skip_relevance { return Some((false, is_pack)); }
 
         if req_num.is_some() && !is_looking_for_omnibus && !is_pack {
             let unexpected_tpb_terms: Vec<&&str> = tpb_terms.iter().filter(|t| !clean_original.contains(**t)).collect();
@@ -578,14 +674,11 @@ pub async fn filter_and_score(
         let tor_year: Option<String> = re_year_find().captures(&title_lower)
             .and_then(|c| c.get(1)).map(|m| m.as_str().to_string());
 
-        // A pack/collection is dated by its SERIES start year, not the requested issue's release year
-        // (beta.069): "Wolverine Complete Collection (2024)" legitimately serves a 2026 issue. So packs
-        // anchor on series_year (falling back to req_year); single issues stay on the per-issue req_year.
-        let effective_year = if is_pack {
-            series_year.as_ref().or(req_year.as_ref())
-        } else {
-            req_year.as_ref()
-        };
+        // A pack/collection's visible year describes the edition more often than the series itself.
+        // A collection's visible year is commonly its edition/repack year (for example a 2025
+        // Thorgal collection for a series that began in 1977), so it cannot discriminate volumes.
+        // True packs are already protected by bounded pack markers plus the core-title check below.
+        let effective_year = if is_pack { None } else { req_year.as_ref() };
 
         let mut year_unconfirmed = false;
         if let Some(req_y) = effective_year {
@@ -614,7 +707,7 @@ pub async fn filter_and_score(
         // Collection"). Applies to Prowlarr (beta.068) AND Anna's Archive — GetComics results run
         // the same guard inside getcomics::search (they bypass this filter via skip_relevance).
         if req_num.is_some() && !is_pack && !significant_query_words.is_empty() {
-            let extra = off_series_extra_words(&title_lower, &significant_query_words);
+            let extra = off_series_extra_words(&match_title_lower, &significant_query_words);
             if !extra.is_empty() {
                 log::debug!("[Automation Debug] Discarding off-series release \"{}\" — extra series words {:?} not in requested \"{}\".", res.title, extra, clean_original);
                 return None;
@@ -623,12 +716,12 @@ pub async fn filter_and_score(
 
         // Core-title match-ratio reverse-validation — Prowlarr only (H-12).
         if !is_ddl && !significant_query_words.is_empty() {
-            let stripped_title = re_brackets_parens_strip().replace_all(&title_lower, "").to_string();
+            let stripped_title = re_brackets_parens_strip().replace_all(&match_title_lower, "").to_string();
             let result_words: Vec<String> = stripped_title.chars()
                 .map(|c| if c.is_alphanumeric() { c } else { ' ' })
                 .collect::<String>()
                 .split_whitespace()
-                .filter(|w| !stop_words.contains(*w) && w.chars().count() > 2 && Some(*w) != tor_year.as_deref())
+                .filter(|w| !reverse_noise_set().contains(*w) && w.chars().count() > 2 && Some(*w) != tor_year.as_deref())
                 .map(|s| s.to_string())
                 .collect();
             if fails_match_ratio(&significant_query_words, &result_words, is_pack, ratio_config) {
@@ -643,26 +736,28 @@ pub async fn filter_and_score(
             }
         }
         for w in &words_to_enforce {
-            if !w.chars().all(char::is_numeric) && !title_lower.contains(w) { return None; }
+            if !w.chars().all(char::is_numeric) && !match_title_lower.contains(w) { return None; }
         }
 
-        Some(year_unconfirmed)
+        Some((year_unconfirmed, is_pack))
     };
 
-    let mut kept: Vec<(ProwlarrResult, bool)> = Vec::new();
+    let mut kept: Vec<(ProwlarrResult, bool, bool)> = Vec::new();
     for res in results {
-        if let Some(unconfirmed) = evaluate(&res) {
-            kept.push((res, unconfirmed));
+        if let Some((unconfirmed, is_pack)) = evaluate(&res) {
+            kept.push((res, unconfirmed, is_pack));
         }
     }
 
     if kept.is_empty() { return Ok(None); }
 
-    // Tiered sort: year-confirmed (false) before unconfirmed (true), then score within each tier.
-    // With prowlarr_accept_yearless off no survivor is ever flagged, so this reduces to the original
-    // pure score ordering — the default path is bit-for-bit the old behavior.
+    // When the operator explicitly prioritizes packs, real pack candidates form the first tier.
+    // Inside each tier, year-confirmed releases still outrank unconfirmed ones, then normal scoring
+    // applies. Without the setting this reduces to the previous year/score ordering.
     kept.sort_by(|a, b| {
-        a.1.cmp(&b.1).then_with(|| {
+        let pack_tier_a = prioritize_packs && !a.2;
+        let pack_tier_b = prioritize_packs && !b.2;
+        pack_tier_a.cmp(&pack_tier_b).then_with(|| a.1.cmp(&b.1)).then_with(|| {
             let score_a = calculate_score(&a.0, &scoring_rules);
             let score_b = calculate_score(&b.0, &scoring_rules);
             score_b.partial_cmp(&score_a).unwrap_or(std::cmp::Ordering::Equal)
@@ -891,6 +986,39 @@ mod tests {
         let no_number = generate_search_queries("Saga", "2014", &ac, false, true);
         assert!(no_number.iter().any(|q| q == "Saga collection"));
         assert!(no_number.iter().any(|q| q == "Saga pack"));
+
+        // A configured localized alias leads the prioritized pack group.
+        let localized = HashMap::from([("elves".to_string(), "elfes".to_string())]);
+        let localized_packs = generate_search_queries("Elves 3", "2016", &localized, true, true);
+        assert_eq!(localized_packs.first().map(String::as_str), Some("elfes"));
+        let localized_idx = localized_packs.iter().position(|q| q == "elfes collection").unwrap();
+        let metadata_idx = localized_packs.iter().position(|q| q == "Elves collection").unwrap();
+        assert!(localized_idx < metadata_idx);
+    }
+
+    #[test]
+    fn localized_pack_detection_is_bounded_and_understands_french_ranges() {
+        assert!(!is_pack_title("Thorgal.le.cycle.de.Qa.2012.FRENCH.REPACK.CBZ"));
+        assert!(is_pack_title("Thorgal.Collection.73 Albums.FR.CBZ"));
+        assert!(is_pack_title("Thorgal intégrale 38 albums + 3 hors-série"));
+        assert!(is_pack_title("Thorgal T1 à T39 [CBZ]"));
+        assert!(is_pack_title("Elfes.T1.T35.FR.[CBZ]"));
+        assert_eq!(parse_issue_range("Thorgal T1 à T39 [CBZ]"), Some((1, 39)));
+        assert_eq!(parse_issue_range("Elfes.T1.T35.FR.[CBZ]"), Some((1, 35)));
+        assert_eq!(parse_issue_range("Thorgal (2008-2010)"), None);
+    }
+
+    #[test]
+    fn configured_expansion_is_also_a_bidirectional_match_alias() {
+        let aliases = HashMap::from([("elves".to_string(), "elfes".to_string())]);
+        assert_eq!(
+            canonicalize_title_aliases("Elfes 003 FRENCH", "Elves #3", &aliases),
+            "elves 003 french"
+        );
+        assert_eq!(
+            canonicalize_title_aliases("Elves 003 English", "Elfes #3", &aliases),
+            "elfes 003 english"
+        );
     }
 
     // ---- Issue #176 characterization: query normalization ALREADY strips punctuation and the year is
@@ -977,6 +1105,8 @@ mod tests {
             .connect("sqlite::memory:").await.unwrap();
         sqlx::query(r#"CREATE TABLE "SystemSetting" (key TEXT PRIMARY KEY, value TEXT)"#)
             .execute(&pool).await.unwrap();
+        sqlx::query(r#"CREATE TABLE "SearchAcronym" (key TEXT PRIMARY KEY, value TEXT)"#)
+            .execute(&pool).await.unwrap();
         for (k, v) in settings {
             sqlx::query(r#"INSERT INTO "SystemSetting" (key, value) VALUES ($1, $2)"#)
                 .bind(*k).bind(*v).execute(&pool).await.unwrap();
@@ -1059,5 +1189,49 @@ mod tests {
             res_p(high, 50, 0, "torrent"),
         ]).await;
         assert_eq!(got.map(|r| r.title), Some(high.to_string()));
+    }
+
+
+    #[tokio::test]
+    async fn prioritize_packs_changes_final_exhaustive_result_ranking() {
+        let pool = mem_pool(&[
+            ("allow_bulk_packs", "true"),
+            ("prioritize_packs", "true"),
+            ("prowlarr_accept_yearless", "true"),
+        ]).await;
+        // 2025 is the collection edition year, not the 2011 metadata-series start year.
+        let pack = "Thorgal.Collection.73 Albums.2025.FR.CBZ";
+        let single = "Thorgal 001 (2011) (Digital).CBZ";
+        let got = filter_and_score(
+            &pool,
+            vec![res_p(single, 500, 100, "torrent"), res_p(pack, 1, 0, "torrent")],
+            "Thorgal #1: Die Rache der Zauberin",
+            false,
+            Some("2011".into()),
+            Some("2011".into()),
+            false,
+            Some(true),
+        ).await.unwrap();
+        assert_eq!(got.map(|r| r.title), Some(pack.to_string()));
+    }
+
+
+    #[tokio::test]
+    async fn configured_localized_alias_survives_the_strict_result_filter() {
+        let pool = mem_pool(&[]).await;
+        sqlx::query(r#"INSERT INTO "SearchAcronym" (key, value) VALUES ('elves', 'elfes')"#)
+            .execute(&pool).await.unwrap();
+        let localized = "Elfes 003 (2016) FRENCH CBZ";
+        let got = filter_and_score(
+            &pool,
+            vec![res_p(localized, 10, 0, "usenet")],
+            "Elves #3: White Elf, Black Heart",
+            false,
+            Some("2016".into()),
+            Some("2016".into()),
+            false,
+            Some(false),
+        ).await.unwrap();
+        assert_eq!(got.map(|r| r.title), Some(localized.to_string()));
     }
 }

--- a/omnibus-engine/src/watched_sync.rs
+++ b/omnibus-engine/src/watched_sync.rs
@@ -151,9 +151,13 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
     for row in settings {
         let key: String = row.get("key");
         let val: String = row.get("value");
-        if key == "folder_naming_pattern" { folder_pattern = val.clone(); }
-        if key == "file_naming_pattern" { file_pattern = val.clone(); }
-        if key == "manga_file_naming_pattern" { manga_file_pattern = val.clone(); }
+        // Empty settings mean "use the built-in default". Accepting an empty file pattern makes
+        // every issue converge on `.cbz`, silently overwriting the previous issue in a batch.
+        if !val.trim().is_empty() {
+            if key == "folder_naming_pattern" { folder_pattern = val.clone(); }
+            if key == "file_naming_pattern" { file_pattern = val.clone(); }
+            if key == "manga_file_naming_pattern" { manga_file_pattern = val.clone(); }
+        }
     }
 
     // Bool columns are CAST for the Any driver — SQLite's BOOLEAN decltype has no mapping.
@@ -168,20 +172,45 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
     let (manga_pubs, western_pubs) = crate::manga_detector::get_detector_settings(&db.pool).await;
     let manga_http = reqwest::Client::new();
 
+    // Scene packs frequently omit ComicInfo.xml entirely. Build a conservative list of existing
+    // series names and their configured localized aliases so a filename such as `Thorgal T01` or
+    // `Elfes.T1` can still be imported. The parser below requires an explicit T/Tome number directly
+    // after the series name; spin-offs (`XIII Mystery`, `Thorgal Saga`) and hors-series stay unmatched.
+    let series_rows = sqlx::query(r#"SELECT name FROM "Series""#).fetch_all(&db.pool).await?;
+    let acronym_rows = sqlx::query(r#"SELECT key, value FROM "SearchAcronym""#).fetch_all(&db.pool).await?;
+    let mut filename_series_candidates = Vec::new();
+    for row in series_rows {
+        let canonical: String = row.get("name");
+        filename_series_candidates.push((canonical.clone(), canonical.clone()));
+        for alias_row in &acronym_rows {
+            let key: String = alias_row.get("key");
+            let value: String = alias_row.get("value");
+            if key.eq_ignore_ascii_case(&canonical) {
+                filename_series_candidates.push((value, canonical.clone()));
+            } else if value.eq_ignore_ascii_case(&canonical) {
+                filename_series_candidates.push((key, canonical.clone()));
+            }
+        }
+    }
+    filename_series_candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0.len()));
+
     let mut success_count = 0;
     let mut unmatched_count = 0;
     let mut synced_series_ids = std::collections::HashSet::new();
 
     for file_data in preprocessed_files {
         let path = file_data.working_path;
-        
-        if let Some(info) = file_data.meta {
+
+        let metadata = file_data.meta.or_else(|| {
+            infer_comicinfo_from_filename(&path, &filename_series_candidates)
+        });
+        if let Some(info) = metadata {
             if info.series.is_none() {
                 if move_to_unmatched(&path, &unmatched_dir).is_ok() { unmatched_count += 1; }
                 continue;
             }
 
-            let series_name = info.series.clone().unwrap_or_else(|| "Unknown".to_string());
+            let mut series_name = info.series.clone().unwrap_or_else(|| "Unknown".to_string());
             let publisher = info.publisher.clone().unwrap_or_else(|| "Other".to_string());
             // ComicInfo <Volume> usually holds the start year; fall back to <Year> (parity with
             // parseComicInfo / metadata-extractor.ts). 0 means "unknown" — rendered as "" in the
@@ -230,22 +259,52 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
                 ("LOCAL".to_string(), String::new())
             };
 
-            if meta_source == "LOCAL" || meta_id.is_empty() {
-                log::info!("[Watched Sync] '{}' has no ComicVine/Metron ID; routing to unmatched for review.", series_name);
+            // Prefer provider IDs. Scene packs often carry useful ComicInfo (Series + Number) but no
+            // ComicVine/Metron IDs; in that case accept only one unambiguous EXISTING local series,
+            // including a configured localized alias (for example ComicVine "Elves" ↔ "Elfes").
+            // Never create a new series from name alone, and never pick between duplicate names.
+            let existing_series = if meta_source == "LOCAL" || meta_id.is_empty() {
+                let alias = sqlx::query(
+                    r#"SELECT key, value FROM "SearchAcronym"
+                       WHERE lower(key) = lower($1) OR lower(value) = lower($1) LIMIT 1"#
+                )
+                .bind(&series_name)
+                .fetch_optional(&db.pool).await?;
+                let alternate_name = alias.map(|row| {
+                    let key: String = row.get("key");
+                    let value: String = row.get("value");
+                    if key.eq_ignore_ascii_case(&series_name) { value } else { key }
+                }).unwrap_or_else(|| series_name.clone());
+
+                let mut candidates = sqlx::query(
+                    r#"SELECT id, name, CAST("isManga" AS INTEGER) AS "isManga", "libraryId", "folderPath"
+                       FROM "Series"
+                       WHERE lower(name) = lower($1) OR lower(name) = lower($2)"#
+                )
+                .bind(&series_name).bind(&alternate_name)
+                .fetch_all(&db.pool).await?;
+
+                if candidates.len() == 1 {
+                    log::info!("[Watched Sync] Matched ID-less pack entry '{}' to the unique existing series '{}'.", series_name, alternate_name);
+                    candidates.pop()
+                } else {
+                    log::info!("[Watched Sync] '{}' has no provider ID and resolved to {} existing series; routing to unmatched.", series_name, candidates.len());
+                    None
+                }
+            } else {
+                // Provider-backed files remain strict by the (metadataSource, metadataId) unique key.
+                sqlx::query(
+                    r#"SELECT id, name, CAST("isManga" AS INTEGER) AS "isManga", "libraryId", "folderPath" FROM "Series"
+                       WHERE "metadataSource" = $1 AND "metadataId" = $2"#
+                )
+                .bind(&meta_source).bind(&meta_id)
+                .fetch_optional(&db.pool).await?
+            };
+
+            if (meta_source == "LOCAL" || meta_id.is_empty()) && existing_series.is_none() {
                 if move_to_unmatched(&path, &unmatched_dir).is_ok() { unmatched_count += 1; }
                 continue;
             }
-
-            // Match an existing series strictly by the (metadataSource, metadataId) unique key, like
-            // Node's findUnique. The earlier name+publisher OR clause could merge two distinct series
-            // or shadow a real ID match on a stale name collision.
-            let existing_series = sqlx::query(
-                // isManga is CAST for the Any driver (no SQLite BOOLEAN mapping).
-                r#"SELECT id, CAST("isManga" AS INTEGER) AS "isManga", "libraryId", "folderPath" FROM "Series"
-                   WHERE "metadataSource" = $1 AND "metadataId" = $2"#
-            )
-            .bind(&meta_source).bind(&meta_id)
-            .fetch_optional(&db.pool).await?;
 
             let series_id: String;
             let target_lib_id: String;
@@ -253,6 +312,9 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
 
             if let Some(series_row) = existing_series {
                 series_id = series_row.get("id");
+                // Use the canonical existing name for both DB and file naming. Otherwise a localized
+                // ComicInfo alias (`Elfes`) and filename inference (`Elves`) create two parallel sets.
+                series_name = series_row.get("name");
                 is_manga = series_row.get::<i64, _>("isManga") != 0;
                 target_lib_id = series_row.get("libraryId");
                 dest_folder = PathBuf::from(series_row.get::<String, _>("folderPath"));
@@ -495,6 +557,42 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
     let _ = clean_empty_folders(Path::new(&watched_dir), Path::new(&watched_dir));
 
     if !synced_series_ids.is_empty() {
+        // A batch request is attached to the provider volume, not to an Issue relation. Once every
+        // known issue in that volume has a real file, reconcile the old per-issue requests so the UI
+        // does not keep showing AWAITING/STALLED after a pack fulfilled the complete series.
+        for series_id in &synced_series_ids {
+            let metadata_id: Option<String> = sqlx::query_scalar(
+                r#"SELECT "metadataId" FROM "Series" WHERE id = $1"#,
+            )
+            .bind(series_id)
+            .fetch_optional(&db.pool)
+            .await?
+            .flatten();
+            let Some(metadata_id) = metadata_id.filter(|id| !id.is_empty()) else { continue };
+            let total: i64 = sqlx::query_scalar(
+                r#"SELECT COUNT(*) FROM "Issue" WHERE "seriesId" = $1"#,
+            ).bind(series_id).fetch_one(&db.pool).await?;
+            let missing: i64 = sqlx::query_scalar(
+                r#"SELECT COUNT(*) FROM "Issue"
+                   WHERE "seriesId" = $1
+                     AND (status <> 'DOWNLOADED' OR "filePath" IS NULL OR "filePath" = '')"#,
+            ).bind(series_id).fetch_one(&db.pool).await?;
+            if total > 0 && missing == 0 {
+                let result = sqlx::query(&format!(
+                    r#"UPDATE "Request" SET status='COMPLETED', progress=100, "updatedAt"={now}
+                       WHERE "volumeId"=$1
+                         AND status IN ('PENDING', 'DOWNLOADING', 'AWAITING_RELEASE', 'STALLED', 'MANUAL_DDL', 'IMPORTED')"#,
+                    now = db.now_expr()
+                )).bind(&metadata_id).execute(&db.pool).await?;
+                if result.rows_affected() > 0 {
+                    log::info!(
+                        "[Watched Sync] Reconciled {} completed requests for provider volume {}.",
+                        result.rows_affected(), metadata_id
+                    );
+                }
+            }
+        }
+
         let series_list: Vec<String> = synced_series_ids.into_iter().collect();
         let db_clone = db.clone();
         tokio::spawn(async move {
@@ -503,6 +601,46 @@ pub async fn process_watched_folder(db: Db) -> Result<(i32, i32, String)> {
     }
 
     Ok((success_count, unmatched_count, format!("Processed watched folder. Imported: {}. Moved to unmatched: {}.", success_count, unmatched_count)))
+}
+
+fn infer_comicinfo_from_filename(path: &Path, candidates: &[(String, String)]) -> Option<ComicInfo> {
+    let stem = path.file_stem()?.to_string_lossy();
+    let mut matches = Vec::new();
+
+    for (visible_name, canonical_name) in candidates {
+        // Prefer an explicit T/Tome marker, but also accept the common French scene form
+        // `Elfes - 01 - title`. The marker-less branch is capped at three digits so a collection
+        // year cannot be mistaken for an issue number.
+        let pattern = format!(
+            r"(?i)^{}[ ._-]+(?:T(?:ome)?[ ._-]*0*([0-9]+)|0*([0-9]{{1,3}}))(?:[ ._-]|$)",
+            regex::escape(visible_name)
+        );
+        let Ok(re) = Regex::new(&pattern) else { continue };
+        let Some(captures) = re.captures(&stem) else { continue };
+        let Some(number) = captures.get(1).or_else(|| captures.get(2)).map(|m| m.as_str().to_string()) else { continue };
+        if !matches.iter().any(|(series, issue): &(String, String)| {
+            series.eq_ignore_ascii_case(canonical_name) && issue == &number
+        }) {
+            matches.push((canonical_name.clone(), number));
+        }
+    }
+
+    if matches.len() != 1 {
+        return None;
+    }
+    let (series, number) = matches.pop()?;
+    log::info!(
+        "[Watched Sync] Inferred existing series '{}' issue {} from filename '{}'.",
+        series,
+        number,
+        stem
+    );
+    Some(ComicInfo {
+        title: Some(stem.to_string()),
+        series: Some(series),
+        number: Some(number),
+        ..ComicInfo::default()
+    })
 }
 
 fn extract_comicinfo(path: &Path) -> Option<ComicInfo> {
@@ -618,6 +756,43 @@ mod tests {
         assert_eq!(split_to_json(Some("Solo")), r#"["Solo"]"#);
         assert_eq!(split_to_json(Some(" , ,")), "[]"); // empty parts filtered
         assert_eq!(split_to_json(None), "[]");
+    }
+
+    #[test]
+    fn filename_metadata_accepts_main_series_and_localized_alias() {
+        let candidates = vec![
+            ("Thorgal".to_string(), "Thorgal".to_string()),
+            ("XIII".to_string(), "XIII".to_string()),
+            ("Elfes".to_string(), "Elves".to_string()),
+        ];
+        let thorgal = infer_comicinfo_from_filename(
+            Path::new("Thorgal T01 - La Magicienne trahie.cbz"),
+            &candidates,
+        ).unwrap();
+        assert_eq!(thorgal.series.as_deref(), Some("Thorgal"));
+        assert_eq!(thorgal.number.as_deref(), Some("1"));
+
+        let elves = infer_comicinfo_from_filename(Path::new("Elfes.T35.FR.cbz"), &candidates).unwrap();
+        assert_eq!(elves.series.as_deref(), Some("Elves"));
+        assert_eq!(elves.number.as_deref(), Some("35"));
+
+        let elves_dash = infer_comicinfo_from_filename(
+            Path::new("Elfes - 01 - Le crystal des Elfes bleus.cbz"),
+            &candidates,
+        ).unwrap();
+        assert_eq!(elves_dash.series.as_deref(), Some("Elves"));
+        assert_eq!(elves_dash.number.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn filename_metadata_rejects_spin_offs_integrales_and_hors_series() {
+        let candidates = vec![("XIII".to_string(), "XIII".to_string()), ("Thorgal".to_string(), "Thorgal".to_string())];
+        assert!(infer_comicinfo_from_filename(Path::new("XIII.Mystery.2008.T01.cbz"), &candidates).is_none());
+        assert!(infer_comicinfo_from_filename(Path::new("XIII.Intégrale.30.ans.T01.cbz"), &candidates).is_none());
+        assert!(infer_comicinfo_from_filename(Path::new("Thorgal Saga - T01.cbz"), &candidates).is_none());
+        assert!(infer_comicinfo_from_filename(Path::new("Thorgal THS1 - Bonus.cbz"), &candidates).is_none());
+        assert!(infer_comicinfo_from_filename(Path::new("XIII.T13Bis.Enquête.cbz"), &candidates).is_none());
+        assert!(infer_comicinfo_from_filename(Path::new("XIII - 2019 collection.cbz"), &candidates).is_none());
     }
 
     // These regexes decide whether a watched file imports MATCHED or routes to /unmatched —

--- a/src/lib/importer.ts
+++ b/src/lib/importer.ts
@@ -10,11 +10,11 @@ import { SystemNotifier } from './notifications';
 import { syncSeriesMetadata } from './metadata-fetcher'; 
 import { detectManga } from './manga-detector';
 import AdmZip from 'adm-zip';
-import { isSameIssue, extractIssueNumber } from '@/lib/utils/issue-parser';
+import { isSameIssue, extractIssueNumber, isPackTitle } from '@/lib/utils/issue-parser';
 import { STOP_WORDS } from '@/lib/utils/search-terms';
 import { COMIC_EXTENSIONS, COMIC_EXT_REGEX, IMAGE_EXT_REGEX } from '@/lib/utils/formats';
 import { sanitizeFilename as sanitize } from '@/lib/utils/sanitize';
-import { WATCHED_DIR } from '@/lib/utils/paths';
+import { WATCHED_DIR, UNMATCHED_DIR } from '@/lib/utils/paths';
 import { ENGINE_URL, engineHeaders } from '@/lib/engine';
 
 // Engine nested-pack helper (list when destDir is omitted, extract when given). Returns null on any
@@ -448,6 +448,34 @@ export const Importer = {
         }
 
         return true;
+    }
+
+    // A release advertised as a collection/range but delivered as one flat comic archive has no
+    // reliable per-issue boundary. Never fabricate issue #1 (or the last number in a range) from it.
+    // Proper packs containing nested CBZ/CBR files returned through the batch path above; only the
+    // ambiguous flat payload reaches this guard and is held for manual review.
+    const releaseLabel = req.activeDownloadName || path.basename(actualSourceFile);
+    if (isPackTitle(releaseLabel)) {
+        await fs.ensureDir(UNMATCHED_DIR);
+        let heldPath = path.join(UNMATCHED_DIR, path.basename(actualSourceFile));
+        if (fs.existsSync(heldPath)) {
+            heldPath = path.join(UNMATCHED_DIR, `${Date.now()}_${path.basename(actualSourceFile)}`);
+        }
+        if (isFromClient || trackingHash) {
+            await fs.copy(actualSourceFile, heldPath, { overwrite: false });
+        } else {
+            await fs.move(actualSourceFile, heldPath, { overwrite: false });
+        }
+        await prisma.request.update({ where: { id: req.id }, data: { status: 'STALLED' } });
+        Logger.log(`[Importer] Flat collection held for manual review instead of importing it as one issue: ${heldPath}`, 'warn');
+        await Promise.resolve(SystemNotifier.sendAlert('download_failed', {
+            title: releaseLabel,
+            imageUrl: req.imageUrl ?? undefined,
+            user: req.user?.username,
+            email: req.user?.email,
+            description: `The downloaded collection did not contain separate comic archives, so Omnibus held it in Unmatched instead of assigning the whole file to one issue.`
+        })).catch(() => {});
+        return false;
     }
 
     // --- DUAL PROVIDER METADATA FETCHING ---

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -253,7 +253,10 @@ export function initWorker() {
                     }
 
                     try {
-                        const rustResponse = await fetch(ENGINE_URL + '/api/automation/search', {
+                        // Prowlarr may legitimately take longer than undici's ~5 minute headers
+                        // timeout when several localized/pack variants hit slow indexers. Keep the
+                        // Node→engine connection open until the exhaustive search has completed.
+                        const rustResponse = await engineFetchLong(ENGINE_URL + '/api/automation/search', {
                             method: 'POST',
                             headers: engineHeaders({ 'Content-Type': 'application/json' }),
                             body: JSON.stringify({

--- a/src/lib/search-engine.ts
+++ b/src/lib/search-engine.ts
@@ -110,16 +110,22 @@ export function generateSearchQueries(name: string, year: string, acronyms: Reco
     
     if (usePacks) {
         const seriesOnlyName = broadClean.replace(/\s\d+(?:\.\d+)?$/, '').trim();
-        if (seriesOnlyName !== broadClean && seriesOnlyName.length > 2) {
-            packQueries.add(seriesOnlyName);
-            packQueries.add(`${seriesOnlyName} collection`);
-            packQueries.add(`${seriesOnlyName} story arc`);
-            packQueries.add(`${seriesOnlyName} pack`);
-        } else if (seriesOnlyName.length > 2) {
-            packQueries.add(`${seriesOnlyName} collection`);
-            packQueries.add(`${seriesOnlyName} story arc`);
-            packQueries.add(`${seriesOnlyName} pack`);
+        const expandedSeriesOnly = expanded.replace(/\s\d+(?:\.\d+)?$/, '').trim();
+        const addPackQueries = (seriesName: string, strippedIssue: boolean) => {
+            if (seriesName.length <= 2) return;
+            if (strippedIssue) packQueries.add(seriesName);
+            packQueries.add(`${seriesName} collection`);
+            packQueries.add(`${seriesName} story arc`);
+            packQueries.add(`${seriesName} pack`);
+            packQueries.add(`${seriesName} integrale`);
+            packQueries.add(`${seriesName} albums`);
+            packQueries.add(`${seriesName} tomes`);
+        };
+
+        if (expandedSeriesOnly.toLowerCase() !== seriesOnlyName.toLowerCase()) {
+            addPackQueries(expandedSeriesOnly, expandedSeriesOnly !== expanded);
         }
+        addPackQueries(seriesOnlyName, seriesOnlyName !== broadClean);
     }
 
     // The bare main-title queries (e.g. "X Men" / "X Men 2026" from a colon-split "X-Men: Outback #1")

--- a/src/lib/utils/issue-parser.ts
+++ b/src/lib/utils/issue-parser.ts
@@ -85,15 +85,28 @@ export function extractIssueNumber(filename: string): string {
 // Kept in lock-step with the Rust engine's getcomics.rs parse_issue_range.
 export function parseIssueRange(title: string): { start: number; end: number } | null {
     if (!title) return null;
-    const rangeRegex = /(?:#|issues?\s*#?|vol(?:ume)?\.?\s*|v\.?\s*)?(\d{1,4})\s*(?:[-–—]|\bto\b)\s*#?(\d{1,4})/gi;
-    let m: RegExpExecArray | null;
-    while ((m = rangeRegex.exec(title)) !== null) {
-        const start = parseInt(m[1], 10);
-        const end = parseInt(m[2], 10);
-        if (isNaN(start) || isNaN(end)) continue;
-        const bothLookLikeYears = start >= 1900 && start <= 2099 && end >= 1900 && end <= 2099;
-        if (bothLookLikeYears) continue;
-        if (end > start) return { start, end };
+    const patterns = [
+        /(?:#|issues?\s*#?|vol(?:ume)?\.?\s*|v\.?\s*|t(?:ome)?s?\.?\s*|albums?\.?\s*)?(\d{1,4})\s*(?:[-–—]|\bto\b|\bau\b|à)\s*(?:#|vol(?:ume)?\.?\s*|v\.?\s*|t(?:ome)?\.?\s*)?(\d{1,4})/gi,
+        /(?:^|[^\p{L}\p{N}])t(?:ome)?\.?\s*(\d{1,4})[\s._-]+t(?:ome)?\.?\s*(\d{1,4})(?:$|[^\p{L}\p{N}])/giu,
+    ];
+    for (const rangeRegex of patterns) {
+        let m: RegExpExecArray | null;
+        while ((m = rangeRegex.exec(title)) !== null) {
+            const start = parseInt(m[1], 10);
+            const end = parseInt(m[2], 10);
+            if (isNaN(start) || isNaN(end)) continue;
+            const bothLookLikeYears = start >= 1900 && start <= 2099 && end >= 1900 && end <= 2099;
+            if (bothLookLikeYears) continue;
+            if (end > start) return { start, end };
+        }
     }
     return null;
+}
+
+/** True only for real multi-issue markers. `REPACK` is deliberately not a pack. */
+export function isPackTitle(title: string): boolean {
+    if (!title) return false;
+    const marker = /(?:^|[^\p{L}\p{N}])(?:pack|story[\s._-]*arc|complete|complet(?:e|es)?|collection|bundle|run|chronological|integrale|intégrale|m[ée]ga[\s._-]*pack|giga[\s._-]*pack)(?:$|[^\p{L}\p{N}])/iu;
+    const countedFrench = /(?:^|[^\p{L}\p{N}])\d+\s*(?:albums|tomes|hors[\s._-]*s[ée]rie(?:s)?|h\.?s\.?)\b/iu;
+    return marker.test(title) || countedFrench.test(title) || parseIssueRange(title) !== null;
 }


### PR DESCRIPTION
## Summary

This PR improves automated comic searches and batch imports for localized releases, especially French BD naming conventions.

It adds:

- bidirectional localized aliases during query generation and strict result filtering;
- collection-oriented queries such as `pack`, `collection`, `story arc`, `integrale`, `albums`, and `tomes`;
- support for French issue ranges such as `T1 à T39` and compact ranges such as `T1.T35`;
- optional pack prioritization without penalizing undated collection releases;
- longer engine request handling for exhaustive Prowlarr searches;
- safe routing of nested comic archives from downloaded packs to the watched folder;
- conservative matching of ID-less scene releases to an existing unique series;
- filename-based issue detection for releases without `ComicInfo.xml`;
- automatic completion of requests fulfilled by a full-series pack.

## Motivation

Localized comic releases often use names that differ significantly from their metadata provider titles.

For example, a provider-backed search may use:

- `Elves #3`
- `Thorgal #38`

while French indexers expose releases such as:

- `Elfes.T1.T35.FR.[CBZ]`
- `Thorgal.T1.a.T39.[CBZ]`
- `Thorgal.Collection.73.Albums.FRENCH.[CBZ]`
- `Thorgal.Pack.01-2026.FR.CBZ`

Previously, these releases could be missed by strict title matching, rejected because a collection had no year, or downloaded without importing the individual issues contained in the pack.

## Search behavior

Configured `SearchAcronym` entries are now usable in both directions.

For example, an alias such as:

```text
Elves = Elfes
```

allows searches and result validation to recognize either title without weakening matching for unrelated series.

When bulk pack searching is enabled, Omnibus also generates localized collection queries and recognizes:

- explicit pack and collection markers;
- French `intégrale`, `albums`, and `tomes` markers;
- issue ranges using `to`, `à`, or compact `T1.T35` notation.

Collection results are not rejected solely because they do not contain the individual issue's publication year.

## Import safety

The batch importer extracts nested comic archives and routes them through the watched-folder pipeline.

ID-less files are imported only when their series name or configured localized alias resolves to exactly one existing series. The importer does not create a new series from an ambiguous name-only match.

Files without `ComicInfo.xml` may be matched from conservative filename forms such as:

- `Thorgal T01 - Title.cbz`
- `XIII.T20.Title.cbz`
- `Elfes - 01 - Title.cbz`

Related titles and spin-offs such as `XIII Mystery` or `Thorgal Saga` are not folded into the main series automatically.

Additional safeguards include:

- `REPACK` is not treated as a collection marker;
- a flat collection archive without separate issue files is held in `unmatched` for manual review;
- an empty naming-pattern setting falls back to the built-in default instead of producing `.cbz`;
- localized aliases use the canonical existing series name for final file naming;
- requests are marked complete only when every known issue in the provider volume has a real downloaded file.

## Validation

- `npm test`: 80 test files, 380 tests passed
- `npx tsc --noEmit`: passed
- `cargo test`: 168 tests passed
- `cargo clippy --all-targets -- -D warnings`: passed
- Docker validation with real localized packs:
  - Thorgal: 43 distinct issues imported
  - Elves / Elfes: 35 distinct issues imported
  - XIII: 30 distinct issues imported

## Scope

This PR does not automatically merge related or spin-off series into a parent series. Those releases remain unmatched unless the related series exists independently in the library.
